### PR TITLE
完善语音设置与录音稳定性，并新增标准/CUDA 双版本打包

### DIFF
--- a/.idea/AIpet.iml
+++ b/.idea/AIpet.iml
@@ -4,4 +4,7 @@
     <option name="format" value="PLAIN" />
     <option name="myDocStringFormat" value="Plain" />
   </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="py.test" />
+  </component>
 </module>

--- a/README.md
+++ b/README.md
@@ -171,18 +171,28 @@ $env:QT_QPA_PLATFORM = "offscreen"
 python -m unittest discover -s tests -v
 ```
 
-Build the single-file Windows executable with:
+Build both single-file Windows executables with:
 
 ```powershell
 .\packaging\build_exe.ps1
 ```
 
 The script creates an isolated `aipet_build_whisper` Conda environment when
-needed and writes `dist\AIpet.exe`. Reuse the installed build dependencies with:
+needed and writes:
+
+- `dist\AIpet.exe`: standard CPU build.
+- `dist\AIpet-with-cuda.exe`: CUDA build with the CUDA 12 cuBLAS, cuDNN 9,
+  and NVRTC runtime bundled for local Whisper GPU inference.
+
+Reuse the installed build dependencies with:
 
 ```powershell
 .\packaging\build_exe.ps1 -SkipDependencyInstall
 ```
+
+When skipping dependency installation, the build environment must already
+contain `cublas64_12.dll` and `cublasLt64_12.dll`. Alternatively, provide their
+directory with `-CudaDllDirectory`.
 
 Main project areas:
 

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -164,18 +164,26 @@ $env:QT_QPA_PLATFORM = "offscreen"
 python -m unittest discover -s tests -v
 ```
 
-构建 Windows 单文件 EXE：
+同时构建两个 Windows 单文件 EXE：
 
 ```powershell
 .\packaging\build_exe.ps1
 ```
 
-脚本会在需要时创建独立的 `aipet_build_whisper` Conda 环境，最终输出
-`dist\AIpet.exe`。构建环境未变化时可跳过依赖安装：
+脚本会在需要时创建独立的 `aipet_build_whisper` Conda 环境，并输出：
+
+- `dist\AIpet.exe`：标准 CPU 版本。
+- `dist\AIpet-with-cuda.exe`：附带 CUDA 12 cuBLAS、cuDNN 9 和 NVRTC
+  运行库，可用于本地 Whisper GPU 推理的 CUDA 版本。
+
+构建环境未变化时可跳过依赖安装：
 
 ```powershell
 .\packaging\build_exe.ps1 -SkipDependencyInstall
 ```
+
+跳过依赖安装时，构建环境中必须已有 `cublas64_12.dll` 和
+`cublasLt64_12.dll`；也可以通过 `-CudaDllDirectory` 指定它们所在的目录。
 
 主要目录：
 

--- a/main.py
+++ b/main.py
@@ -157,6 +157,7 @@ def configure_voice_trigger(
     try:
         from tool.voice_trigger import CapslockVoiceTrigger
     except ImportError as exc:
+        logger.exception("语音输入模块加载失败")
         tray_icon.showMessage(
             ui_text(settings, "speech_unavailable"),
             ui_text(settings, "install_voice", error=exc),
@@ -202,6 +203,7 @@ def configure_voice_trigger(
     try:
         trigger.start()
     except Exception as exc:
+        logger.exception("语音触发器启动失败")
         tray_icon.showMessage(
             ui_text(settings, "speech_failed"),
             str(exc),

--- a/packaging/AIpet.spec
+++ b/packaging/AIpet.spec
@@ -1,11 +1,60 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+import os
 from pathlib import Path
 
 from PyInstaller.utils.hooks import collect_data_files
 
 
 project_root = Path(SPECPATH).parent
+build_variant = os.environ.get("AIPET_BUILD_VARIANT", "standard").strip()
+if build_variant not in {"standard", "with-cuda"}:
+    raise SystemExit(
+        "AIPET_BUILD_VARIANT must be 'standard' or 'with-cuda'."
+    )
+
+app_name = "AIpet-with-cuda" if build_variant == "with-cuda" else "AIpet"
+cublas_dll_names = ("cublas64_12.dll", "cublasLt64_12.dll")
+cudnn_dll_names = (
+    "cudnn64_9.dll",
+    "cudnn_adv64_9.dll",
+    "cudnn_cnn64_9.dll",
+    "cudnn_engines_precompiled64_9.dll",
+    "cudnn_engines_runtime_compiled64_9.dll",
+    "cudnn_graph64_9.dll",
+    "cudnn_heuristic64_9.dll",
+    "cudnn_ops64_9.dll",
+)
+nvrtc_dll_names = ("nvrtc64_120_0.dll",)
+binaries = []
+if build_variant == "with-cuda":
+    cublas_dll_directory = Path(
+        os.environ.get("AIPET_CUDA_DLL_DIR", "")
+    )
+    cudnn_dll_directory = Path(
+        os.environ.get("AIPET_CUDNN_DLL_DIR", "")
+    )
+    nvrtc_dll_directory = Path(
+        os.environ.get("AIPET_CUDA_NVRTC_DLL_DIR", "")
+    )
+    cuda_dll_paths = [
+        *(cublas_dll_directory / name for name in cublas_dll_names),
+        *(cudnn_dll_directory / name for name in cudnn_dll_names),
+        *(nvrtc_dll_directory / name for name in nvrtc_dll_names),
+        *nvrtc_dll_directory.glob("nvrtc-builtins64_*.dll"),
+    ]
+    missing_cuda_dlls = [
+        str(path) for path in cuda_dll_paths if not path.is_file()
+    ]
+    if missing_cuda_dlls:
+        raise SystemExit(
+            "CUDA build is missing required DLLs: "
+            f"{', '.join(missing_cuda_dlls)}"
+        )
+    binaries.extend(
+        (str(path), ".")
+        for path in cuda_dll_paths
+    )
 
 datas = [
     (str(project_root / "fgimages"), "fgimages"),
@@ -18,7 +67,7 @@ datas += collect_data_files("faster_whisper")
 a = Analysis(
     [str(project_root / "main.py")],
     pathex=[str(project_root)],
-    binaries=[],
+    binaries=binaries,
     datas=datas,
     hiddenimports=[],
     hookspath=[],
@@ -36,6 +85,27 @@ a = Analysis(
     optimize=0,
 )
 
+# PyQt5 bundles an outdated MSVC runtime under Qt5/bin while Conda provides a
+# current, backward-compatible copy at the application root. Keeping both lets
+# the Windows loader select Qt's old MSVCP140.dll for CTranslate2, which can
+# crash during CUDA error handling. Retain only the root runtime DLLs.
+msvc_runtime_names = {
+    "msvcp140.dll",
+    "msvcp140_1.dll",
+    "vcruntime140.dll",
+    "vcruntime140_1.dll",
+}
+a.binaries[:] = [
+    entry
+    for entry in a.binaries
+    if not (
+        str(entry[0]).replace("\\", "/").lower().startswith(
+            "pyqt5/qt5/bin/"
+        )
+        and Path(entry[0]).name.lower() in msvc_runtime_names
+    )
+]
+
 pyz = PYZ(a.pure)
 
 exe = EXE(
@@ -44,7 +114,7 @@ exe = EXE(
     a.binaries,
     a.datas,
     [],
-    name="AIpet",
+    name=app_name,
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,

--- a/packaging/build_exe.ps1
+++ b/packaging/build_exe.ps1
@@ -1,5 +1,8 @@
 param(
     [string]$EnvironmentName = "aipet_build_whisper",
+    [string]$CudaDllDirectory = "",
+    [string]$CudnnDllDirectory = "",
+    [string]$CudaNvrtcDllDirectory = "",
     [switch]$SkipDependencyInstall
 )
 
@@ -12,27 +15,52 @@ $requirementsPath = Join-Path $packagingRoot "requirements-build.txt"
 $specPath = Join-Path $packagingRoot "AIpet.spec"
 $distPath = Join-Path $projectRoot "dist"
 $workPath = Join-Path $projectRoot "build"
+$cublasDllNames = @(
+    "cublas64_12.dll",
+    "cublasLt64_12.dll"
+)
+$cudnnDllNames = @(
+    "cudnn64_9.dll",
+    "cudnn_adv64_9.dll",
+    "cudnn_cnn64_9.dll",
+    "cudnn_engines_precompiled64_9.dll",
+    "cudnn_engines_runtime_compiled64_9.dll",
+    "cudnn_graph64_9.dll",
+    "cudnn_heuristic64_9.dll",
+    "cudnn_ops64_9.dll"
+)
+$nvrtcDllNames = @("nvrtc64_120_0.dll")
 
 if (-not (Get-Command conda -ErrorAction SilentlyContinue)) {
     throw "Conda was not found on PATH."
 }
 
-$environmentList = (& conda env list --json | ConvertFrom-Json).envs
+function Get-CondaEnvironmentPath {
+    param([string]$Name)
+
+    $environmentList = (& conda env list --json | ConvertFrom-Json).envs
+    if ($LASTEXITCODE -ne 0) {
+        throw "Unable to list Conda environments."
+    }
+    return $environmentList | Where-Object {
+        (Split-Path $_ -Leaf) -ieq $Name
+    } | Select-Object -First 1
+}
+
+$buildEnvironmentPath = Get-CondaEnvironmentPath $EnvironmentName
 if ($LASTEXITCODE -ne 0) {
     throw "Unable to list Conda environments."
 }
 
-$environmentExists = @(
-    $environmentList | Where-Object {
-        (Split-Path $_ -Leaf) -ieq $EnvironmentName
-    }
-).Count -gt 0
-
-if (-not $environmentExists) {
+if (-not $buildEnvironmentPath) {
     Write-Host "Creating Conda environment: $EnvironmentName"
     & conda create -n $EnvironmentName python=3.10 pip -y
     if ($LASTEXITCODE -ne 0) {
         throw "Unable to create Conda environment: $EnvironmentName"
+    }
+    $buildEnvironmentPath = Get-CondaEnvironmentPath $EnvironmentName
+    if (-not $buildEnvironmentPath) {
+        throw "The newly created Conda environment could not be located."
     }
 }
 
@@ -44,6 +72,22 @@ if (-not $SkipDependencyInstall) {
         -r $requirementsPath
     if ($LASTEXITCODE -ne 0) {
         throw "Dependency installation failed."
+    }
+
+    if (
+        -not $CudaDllDirectory -or
+        -not $CudnnDllDirectory -or
+        -not $CudaNvrtcDllDirectory
+    ) {
+        Write-Host "Installing the CUDA 12 cuBLAS/cuDNN 9 runtime..."
+        & conda install -n $EnvironmentName -c conda-forge `
+            "libcublas>=12,<13" `
+            "cudnn>=9,<10" `
+            "cuda-nvrtc>=12,<13" `
+            -y
+        if ($LASTEXITCODE -ne 0) {
+            throw "CUDA runtime installation failed."
+        }
     }
 }
 
@@ -92,28 +136,171 @@ if ($LASTEXITCODE -ne 0) {
     throw "The build environment is incomplete or contains heavyweight extras."
 }
 
-Write-Host "Building AIpet.exe..."
-Push-Location $projectRoot
-try {
-    & conda run -n $EnvironmentName python -m PyInstaller `
-        --noconfirm `
-        --clean `
-        --distpath $distPath `
-        --workpath $workPath `
-        $specPath
-    if ($LASTEXITCODE -ne 0) {
-        throw "PyInstaller failed."
+if (-not $CudaDllDirectory) {
+    $CudaDllDirectory = Join-Path $buildEnvironmentPath "Library\bin"
+}
+if (-not $CudnnDllDirectory) {
+    $CudnnDllDirectory = Join-Path $buildEnvironmentPath "Library\bin"
+}
+if (-not $CudaNvrtcDllDirectory) {
+    $CudaNvrtcDllDirectory = Join-Path $buildEnvironmentPath "Library\bin"
+}
+$CudaDllDirectory = [System.IO.Path]::GetFullPath($CudaDllDirectory)
+$CudnnDllDirectory = [System.IO.Path]::GetFullPath($CudnnDllDirectory)
+$CudaNvrtcDllDirectory = [System.IO.Path]::GetFullPath(
+    $CudaNvrtcDllDirectory
+)
+
+function Assert-DllSet {
+    param(
+        [string]$Directory,
+        [string[]]$Names,
+        [string]$ParameterName
+    )
+
+    $missingDlls = @(
+        $Names | Where-Object {
+            -not (Test-Path -LiteralPath (
+                Join-Path $Directory $_
+            ) -PathType Leaf)
+        }
+    )
+    if ($missingDlls.Count -gt 0) {
+        throw (
+            "CUDA runtime directory is incomplete: $Directory. Missing: " +
+            ($missingDlls -join ", ") +
+            ". Run without -SkipDependencyInstall or pass -$ParameterName."
+        )
     }
 }
-finally {
-    Pop-Location
+
+Assert-DllSet `
+    -Directory $CudaDllDirectory `
+    -Names $cublasDllNames `
+    -ParameterName "CudaDllDirectory"
+Assert-DllSet `
+    -Directory $CudnnDllDirectory `
+    -Names $cudnnDllNames `
+    -ParameterName "CudnnDllDirectory"
+Assert-DllSet `
+    -Directory $CudaNvrtcDllDirectory `
+    -Names $nvrtcDllNames `
+    -ParameterName "CudaNvrtcDllDirectory"
+
+$nvrtcBuiltins = @(
+    Get-ChildItem -LiteralPath $CudaNvrtcDllDirectory `
+        -Filter "nvrtc-builtins64_*.dll" `
+        -File
+)
+if ($nvrtcBuiltins.Count -eq 0) {
+    throw (
+        "CUDA NVRTC directory is incomplete: $CudaNvrtcDllDirectory. " +
+        "Missing: nvrtc-builtins64_*.dll. Run without " +
+        "-SkipDependencyInstall or pass -CudaNvrtcDllDirectory."
+    )
 }
 
-$artifact = Get-Item (Join-Path $distPath "AIpet.exe")
-$hash = Get-FileHash -Algorithm SHA256 $artifact.FullName
+$allCudaDlls = @(
+    $cublasDllNames | ForEach-Object {
+        Join-Path $CudaDllDirectory $_
+    }
+    $cudnnDllNames | ForEach-Object {
+        Join-Path $CudnnDllDirectory $_
+    }
+    $nvrtcDllNames | ForEach-Object {
+        Join-Path $CudaNvrtcDllDirectory $_
+    }
+    $nvrtcBuiltins | ForEach-Object {
+        $_.FullName
+    }
+)
+$duplicateCudaDlls = @(
+    $allCudaDlls |
+        Group-Object { Split-Path $_ -Leaf } |
+        Where-Object Count -gt 1
+)
+if ($duplicateCudaDlls.Count -gt 0) {
+    throw (
+        "CUDA runtime contains duplicate DLL names: " +
+        (($duplicateCudaDlls | ForEach-Object Name) -join ", ")
+    )
+}
+
+$missingCudaDlls = @(
+    $allCudaDlls | Where-Object {
+        -not (Test-Path -LiteralPath (
+            $_
+        ) -PathType Leaf)
+    }
+)
+if ($missingCudaDlls.Count -gt 0) {
+    throw (
+        "CUDA runtime is incomplete. Missing: " +
+        ($missingCudaDlls -join ", ") +
+        "."
+    )
+}
+
+function Invoke-AIpetBuild {
+    param(
+        [string]$Variant,
+        [string]$ArtifactName,
+        [string]$VariantWorkPath
+    )
+
+    Write-Host "Building $ArtifactName..."
+    $previousVariant = $env:AIPET_BUILD_VARIANT
+    $previousCudaDirectory = $env:AIPET_CUDA_DLL_DIR
+    $previousCudnnDirectory = $env:AIPET_CUDNN_DLL_DIR
+    $previousNvrtcDirectory = $env:AIPET_CUDA_NVRTC_DLL_DIR
+    try {
+        $env:AIPET_BUILD_VARIANT = $Variant
+        $env:AIPET_CUDA_DLL_DIR = $CudaDllDirectory
+        $env:AIPET_CUDNN_DLL_DIR = $CudnnDllDirectory
+        $env:AIPET_CUDA_NVRTC_DLL_DIR = $CudaNvrtcDllDirectory
+        Push-Location $projectRoot
+        try {
+            & conda run -n $EnvironmentName python -m PyInstaller `
+                --noconfirm `
+                --clean `
+                --distpath $distPath `
+                --workpath $VariantWorkPath `
+                $specPath | Out-Host
+            if ($LASTEXITCODE -ne 0) {
+                throw "PyInstaller failed for build variant: $Variant"
+            }
+        }
+        finally {
+            Pop-Location
+        }
+    }
+    finally {
+        $env:AIPET_BUILD_VARIANT = $previousVariant
+        $env:AIPET_CUDA_DLL_DIR = $previousCudaDirectory
+        $env:AIPET_CUDNN_DLL_DIR = $previousCudnnDirectory
+        $env:AIPET_CUDA_NVRTC_DLL_DIR = $previousNvrtcDirectory
+    }
+
+    return Get-Item (Join-Path $distPath $ArtifactName)
+}
+
+$artifacts = @(
+    Invoke-AIpetBuild `
+        -Variant "standard" `
+        -ArtifactName "AIpet.exe" `
+        -VariantWorkPath (Join-Path $workPath "standard")
+    Invoke-AIpetBuild `
+        -Variant "with-cuda" `
+        -ArtifactName "AIpet-with-cuda.exe" `
+        -VariantWorkPath (Join-Path $workPath "with-cuda")
+)
 
 Write-Host ""
 Write-Host "Build complete:"
-Write-Host "  File:   $($artifact.FullName)"
-Write-Host "  Size:   $([math]::Round($artifact.Length / 1MB, 1)) MiB"
-Write-Host "  SHA256: $($hash.Hash)"
+foreach ($artifact in $artifacts) {
+    $hash = Get-FileHash -Algorithm SHA256 $artifact.FullName
+    Write-Host "  File:   $($artifact.FullName)"
+    Write-Host "  Size:   $([math]::Round($artifact.Length / 1MB, 1)) MiB"
+    Write-Host "  SHA256: $($hash.Hash)"
+    Write-Host ""
+}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -14,7 +14,9 @@ from tool.audio_devices import (
     decode_audio_input_device,
     encode_audio_input_device,
     list_audio_input_devices,
+    refresh_audio_input_devices,
     resolve_audio_input_device,
+    set_audio_capture_active,
 )
 from tool.backends import (
     APIBackend,
@@ -184,6 +186,41 @@ class CoreTests(unittest.TestCase):
                 (15, "Windows DirectSound"),
             ],
         )
+
+    def test_audio_input_device_refresh_restarts_backend_only_when_idle(
+        self,
+    ) -> None:
+        device = AudioInputDevice(
+            index=7,
+            name="USB Microphone",
+            hostapi="Windows WASAPI",
+            max_input_channels=1,
+        )
+        sounddevice = Mock()
+        try:
+            with (
+                patch.dict("sys.modules", {"sounddevice": sounddevice}),
+                patch("tool.audio_devices._restart_portaudio") as restart,
+                patch(
+                    "tool.audio_devices._compatible_audio_input_devices",
+                    return_value=[device],
+                ),
+                patch(
+                    "tool.audio_devices._default_audio_input_device",
+                    return_value=device,
+                ),
+            ):
+                set_audio_capture_active(False)
+                default_device, devices = refresh_audio_input_devices()
+                self.assertEqual(default_device, device)
+                self.assertEqual(devices, [device])
+                restart.assert_called_once_with(sounddevice)
+
+                set_audio_capture_active(True)
+                refresh_audio_input_devices()
+                restart.assert_called_once_with(sounddevice)
+        finally:
+            set_audio_capture_active(False)
 
     def test_default_model_directory_is_inside_project(self) -> None:
         with patch.dict(

--- a/tests/test_runtime_logging.py
+++ b/tests/test_runtime_logging.py
@@ -16,11 +16,38 @@ from tool.runtime_logging import (
     DailyFileHandler,
     _console_python_executable,
     _viewer_command,
+    configure_console_logging,
     format_json_for_log,
+    get_logger,
+    shutdown_console_logging,
 )
 
 
 class RuntimeLoggingTests(unittest.TestCase):
+    def test_file_logging_stays_enabled_without_console_viewer(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            log_directory = Path(directory)
+            with (
+                patch.object(runtime_logging, "LOG_DIRECTORY", log_directory),
+                patch.object(
+                    runtime_logging,
+                    "LEGACY_LOG_PATH",
+                    log_directory / "missing-legacy.log",
+                ),
+            ):
+                try:
+                    viewer_started = configure_console_logging(False)
+                    get_logger("test").info("persistent log entry")
+                finally:
+                    shutdown_console_logging()
+
+            path = log_directory / f"{date.today().isoformat()}.log"
+            self.assertFalse(viewer_started)
+            self.assertIn(
+                "persistent log entry",
+                path.read_text(encoding="utf-8"),
+            )
+
     def test_daily_handler_writes_to_current_date_file(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             handler = DailyFileHandler(Path(directory))

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -90,21 +90,25 @@ class UISmokeTests(unittest.TestCase):
             hostapi="Windows WASAPI",
             max_input_channels=1,
         )
+        newly_connected = AudioInputDevice(
+            index=41,
+            name="New USB Microphone",
+            hostapi="Windows WASAPI",
+            max_input_channels=1,
+        )
         with tempfile.TemporaryDirectory() as directory:
             settings = AppSettings()
             settings.stt.input_device = selected.identifier
+            settings.stt.device = "cuda"
+            settings.ui_language = "zh-CN"
             with (
                 patch.dict(
                     os.environ,
                     {"AIPET_DATA_DIR": directory},
                 ),
                 patch(
-                    "ui.settings_dialog.list_audio_input_devices",
-                    return_value=[selected],
-                ),
-                patch(
-                    "ui.settings_dialog.default_audio_input_device",
-                    return_value=selected,
+                    "ui.settings_dialog.refresh_audio_input_devices",
+                    return_value=(selected, [selected]),
                 ),
             ):
                 dialog = SettingsDialog(settings)
@@ -116,6 +120,52 @@ class UISmokeTests(unittest.TestCase):
                     self.assertEqual(
                         dialog._form_settings().stt.input_device,
                         selected.identifier,
+                    )
+                    self.assertEqual(dialog.stt_device.currentData(), "cuda")
+                    self.assertEqual(
+                        dialog.stt_device.currentText(),
+                        "CUDA（请使用 AIpet-with-cuda 版本，否则无法使用）",
+                    )
+                    self.assertEqual(
+                        dialog._form_settings().stt.device,
+                        "cuda",
+                    )
+                    dialog._set_combo_data(dialog.language_combo, "en")
+                    self.assertEqual(
+                        dialog.stt_device.currentText(),
+                        (
+                            "CUDA (requires the AIpet-with-cuda build; "
+                            "unavailable otherwise)"
+                        ),
+                    )
+                    with (
+                        patch(
+                            "ui.settings_dialog.refresh_audio_input_devices",
+                            return_value=(selected, [selected, newly_connected]),
+                        ),
+                    ):
+                        dialog._refresh_audio_input_devices()
+                    self.assertEqual(
+                        dialog.stt_input_device.currentData(),
+                        selected.identifier,
+                    )
+                    self.assertGreaterEqual(
+                        dialog.stt_input_device.findData(
+                            newly_connected.identifier
+                        ),
+                        0,
+                    )
+
+                    with patch.object(dialog, "_auto_fetch_models"):
+                        dialog.show()
+                        self.app.processEvents()
+                    self.assertTrue(
+                        dialog._audio_device_refresh_timer.isActive()
+                    )
+                    dialog.hide()
+                    self.app.processEvents()
+                    self.assertFalse(
+                        dialog._audio_device_refresh_timer.isActive()
                     )
                 finally:
                     dialog.close()
@@ -182,6 +232,95 @@ class UISmokeTests(unittest.TestCase):
             for key in tts_label_keys:
                 for label in dialog._form_labels[key]:
                     self.assertFalse(label.isEnabled(), key)
+        finally:
+            dialog.close()
+
+    def test_tts_backend_hides_irrelevant_rows(self) -> None:
+        settings = AppSettings()
+        settings.tts.enabled = False
+        settings.tts.backend = "local"
+        dialog = SettingsDialog(settings)
+        try:
+            local_keys = (
+                "tts_endpoint",
+                "tts_engine_root",
+                "tts_model_dir",
+            )
+            autodl_keys = (
+                "tts_autodl_ssh_command",
+                "tts_autodl_password",
+                "tts_autodl_remote_command",
+                "tts_autodl_reference_root",
+            )
+            for key in local_keys:
+                self.assertFalse(
+                    dialog._form_fields[key][0].isHidden(),
+                    key,
+                )
+                self.assertFalse(
+                    dialog._form_labels[key][0].isHidden(),
+                    key,
+                )
+            for key in autodl_keys:
+                self.assertTrue(
+                    dialog._form_fields[key][0].isHidden(),
+                    key,
+                )
+                self.assertTrue(
+                    dialog._form_labels[key][0].isHidden(),
+                    key,
+                )
+            self.assertFalse(dialog.tts_download_button.isHidden())
+
+            dialog._set_combo_data(dialog.tts_backend, "autodl")
+            for key in local_keys:
+                self.assertTrue(
+                    dialog._form_fields[key][0].isHidden(),
+                    key,
+                )
+                self.assertTrue(
+                    dialog._form_labels[key][0].isHidden(),
+                    key,
+                )
+            for key in autodl_keys:
+                self.assertFalse(
+                    dialog._form_fields[key][0].isHidden(),
+                    key,
+                )
+                self.assertFalse(
+                    dialog._form_labels[key][0].isHidden(),
+                    key,
+                )
+            self.assertTrue(dialog.tts_download_button.isHidden())
+        finally:
+            dialog.close()
+
+    def test_settings_help_buttons_replace_empty_title_bar_help(
+        self,
+    ) -> None:
+        settings = AppSettings(ui_language="zh-CN")
+        with (
+            patch(
+                "ui.settings_dialog.refresh_audio_input_devices",
+                return_value=(None, []),
+            ),
+        ):
+            dialog = SettingsDialog(settings)
+        try:
+            self.assertFalse(
+                bool(dialog.windowFlags() & Qt.WindowContextHelpButtonHint)
+            )
+            with patch(
+                "ui.settings_dialog.QMessageBox.information"
+            ) as information:
+                dialog.automation_help_button.click()
+                information.assert_called_once()
+                self.assertIn("思考提醒", information.call_args.args[2])
+
+                information.reset_mock()
+                dialog.display_help_button.click()
+                information.assert_called_once()
+                self.assertIn("屏幕编号", information.call_args.args[2])
         finally:
             dialog.close()
 

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -145,6 +145,46 @@ class UISmokeTests(unittest.TestCase):
                 notify_if_busy=False,
             )
 
+    def test_disabled_tts_greys_out_all_options(self) -> None:
+        settings = AppSettings()
+        settings.tts.enabled = False
+        dialog = SettingsDialog(settings)
+        try:
+            self.assertTrue(dialog.tts_enabled.isEnabled())
+            for field in (
+                dialog.tts_backend,
+                dialog.tts_url,
+                dialog.tts_timeout,
+                dialog.tts_engine_root,
+                dialog.tts_engine_browse,
+                dialog.tts_model_dir,
+                dialog.tts_model_browse,
+                dialog.tts_autodl_ssh_command,
+                dialog.tts_autodl_password,
+                dialog.tts_autodl_remote_command,
+                dialog.tts_autodl_reference_root,
+                dialog.tts_service_button,
+                dialog.tts_download_button,
+            ):
+                self.assertFalse(field.isEnabled(), field.objectName())
+
+            tts_label_keys = (
+                "tts_backend",
+                "tts_endpoint",
+                "tts_timeout",
+                "tts_engine_root",
+                "tts_model_dir",
+                "tts_autodl_ssh_command",
+                "tts_autodl_password",
+                "tts_autodl_remote_command",
+                "tts_autodl_reference_root",
+            )
+            for key in tts_label_keys:
+                for label in dialog._form_labels[key]:
+                    self.assertFalse(label.isEnabled(), key)
+        finally:
+            dialog.close()
+
     def test_models_tab_does_not_compress_form_rows(self) -> None:
         previous_font = self.app.font()
         try:

--- a/tests/test_whisper_models.py
+++ b/tests/test_whisper_models.py
@@ -100,6 +100,38 @@ class WhisperModelTests(unittest.TestCase):
             transcribe_full("audio.wav", model_size="large-v3")
         whisper_model.assert_not_called()
 
+    def test_auto_device_falls_back_when_lazy_cuda_inference_fails(
+        self,
+    ) -> None:
+        def failing_segments():
+            raise RuntimeError("cublas64_12.dll is missing")
+            yield
+
+        cuda_model = Mock()
+        cuda_model.transcribe.return_value = (failing_segments(), None)
+        cpu_model = Mock()
+        cpu_model.transcribe.return_value = (
+            iter([SimpleNamespace(text="识别成功")]),
+            None,
+        )
+        whisper_model = Mock(side_effect=[cuda_model, cpu_model])
+        module = SimpleNamespace(WhisperModel=whisper_model)
+
+        with (
+            patch.dict(sys.modules, {"faster_whisper": module}),
+            patch(
+                "tool.stt.find_local_model",
+                return_value="C:/models/whisper",
+            ),
+        ):
+            result = transcribe_full("audio.wav", device="auto")
+
+        self.assertEqual(result, "识别成功")
+        self.assertEqual(
+            [call.kwargs["device"] for call in whisper_model.call_args_list],
+            ["cuda", "cpu"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tool/audio_devices.py
+++ b/tool/audio_devices.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
 import json
+import threading
+from contextlib import contextmanager
 from dataclasses import dataclass
+
+
+_AUDIO_BACKEND_LOCK = threading.RLock()
+_AUDIO_CAPTURE_ACTIVE = False
 
 
 @dataclass(frozen=True)
@@ -60,7 +66,8 @@ def _all_compatible_audio_input_devices() -> list[AudioInputDevice]:
     except ImportError:
         return []
 
-    return _compatible_audio_input_devices(sd)
+    with _AUDIO_BACKEND_LOCK:
+        return _compatible_audio_input_devices(sd)
 
 
 def _compatible_audio_input_devices(sd) -> list[AudioInputDevice]:
@@ -152,6 +159,16 @@ def default_audio_input_device() -> AudioInputDevice | None:
     try:
         import sounddevice as sd
 
+        with _AUDIO_BACKEND_LOCK:
+            return _default_audio_input_device(sd)
+    except (ImportError, TypeError, ValueError):
+        return None
+    except Exception:
+        return None
+
+
+def _default_audio_input_device(sd) -> AudioInputDevice | None:
+    try:
         raw = sd.query_devices(kind="input")
         hostapi = sd.query_hostapis(int(raw["hostapi"]))
         default_index = int(sd.default.device[0])
@@ -165,6 +182,52 @@ def default_audio_input_device() -> AudioInputDevice | None:
         return None
     except Exception:
         return None
+
+
+def refresh_audio_input_devices(
+) -> tuple[AudioInputDevice | None, list[AudioInputDevice]]:
+    """Refresh PortAudio when safe, then return the current input devices."""
+
+    try:
+        import sounddevice as sd
+    except ImportError:
+        return None, []
+
+    with _AUDIO_BACKEND_LOCK:
+        if not _AUDIO_CAPTURE_ACTIVE:
+            _restart_portaudio(sd)
+        devices = _preferred_audio_input_devices(
+            _compatible_audio_input_devices(sd)
+        )
+        return _default_audio_input_device(sd), devices
+
+
+def _restart_portaudio(sd) -> None:
+    try:
+        if getattr(sd, "_initialized", 0) > 0:
+            sd._terminate()
+        sd._initialize()
+    except Exception:
+        # A failed refresh must not make the existing settings window unusable.
+        if getattr(sd, "_initialized", 0) <= 0:
+            try:
+                sd._initialize()
+            except Exception:
+                pass
+
+
+@contextmanager
+def audio_backend_access():
+    """Prevent PortAudio refresh while a stream is being opened or closed."""
+
+    with _AUDIO_BACKEND_LOCK:
+        yield
+
+
+def set_audio_capture_active(active: bool) -> None:
+    global _AUDIO_CAPTURE_ACTIVE
+    with _AUDIO_BACKEND_LOCK:
+        _AUDIO_CAPTURE_ACTIVE = active
 
 
 def resolve_audio_input_device(identifier: str) -> int | None:
@@ -193,9 +256,12 @@ def resolve_audio_input_device(identifier: str) -> int | None:
 
 __all__ = [
     "AudioInputDevice",
+    "audio_backend_access",
     "decode_audio_input_device",
     "default_audio_input_device",
     "encode_audio_input_device",
     "list_audio_input_devices",
+    "refresh_audio_input_devices",
     "resolve_audio_input_device",
+    "set_audio_capture_active",
 ]

--- a/tool/runtime_logging.py
+++ b/tool/runtime_logging.py
@@ -84,17 +84,26 @@ def get_logger(component: str | None = None) -> logging.Logger:
 
 
 def configure_console_logging(enabled: bool) -> bool:
-    """Enable or disable AIpet's independent live diagnostic window."""
-    global _file_handler
+    """Configure the optional viewer while keeping file logging enabled."""
+    _ensure_file_logging()
 
     if not enabled:
         _stop_viewer()
-        if _file_handler is not None:
-            _base_logger.removeHandler(_file_handler)
-            _file_handler.close()
-            _file_handler = None
-        sys.excepthook = _original_excepthook
         return False
+
+    viewer_started = _ensure_viewer()
+    get_logger("startup").info(
+        "实时日志查看器已启用 | Python %s | PID %s | 日志=%s",
+        sys.version.split()[0],
+        os.getpid(),
+        LOG_DIRECTORY / f"{date.today().isoformat()}.log",
+    )
+    return viewer_started
+
+
+def _ensure_file_logging() -> None:
+    """Start persistent daily file logging once for this process."""
+    global _file_handler
 
     LOG_DIRECTORY.mkdir(parents=True, exist_ok=True)
     _migrate_legacy_log()
@@ -106,19 +115,18 @@ def configure_console_logging(enabled: bool) -> bool:
         _file_handler = handler
         sys.excepthook = _log_unhandled_exception
 
-    viewer_started = _ensure_viewer()
-    get_logger("startup").info(
-        "实时日志已启用 | Python %s | PID %s | 日志=%s",
-        sys.version.split()[0],
-        os.getpid(),
-        LOG_DIRECTORY / f"{date.today().isoformat()}.log",
-    )
-    return viewer_started
-
 
 def shutdown_console_logging() -> None:
-    get_logger("startup").info("实时日志查看器即将关闭")
-    configure_console_logging(False)
+    """Stop the viewer and close the persistent log file cleanly."""
+    global _file_handler
+
+    get_logger("startup").info("日志系统即将关闭")
+    _stop_viewer()
+    if _file_handler is not None:
+        _base_logger.removeHandler(_file_handler)
+        _file_handler.close()
+        _file_handler = None
+    sys.excepthook = _original_excepthook
 
 
 def log_request(

--- a/tool/stt.py
+++ b/tool/stt.py
@@ -20,29 +20,28 @@ def transcribe_full(
             "Whisper model was not found in the configured model directory. "
             "Select a download directory and download the model in Settings."
         )
-    selected_device = device
-    if selected_device == "auto":
-        selected_device = "cuda"
 
-    compute_type = "float16" if selected_device == "cuda" else "int8"
-    try:
+    def transcribe_with(selected_device: str) -> str:
+        compute_type = "float16" if selected_device == "cuda" else "int8"
         model = WhisperModel(
             selected_model,
             device=selected_device,
             compute_type=compute_type,
         )
-    except Exception:
-        if device != "auto":
-            raise
-        model = WhisperModel(
-            selected_model,
-            device="cpu",
-            compute_type="int8",
+        segments, _ = model.transcribe(
+            audio_path,
+            language="zh",
+            beam_size=5,
         )
+        return "".join(segment.text for segment in segments).strip()
 
-    segments, _ = model.transcribe(
-        audio_path,
-        language="zh",
-        beam_size=5,
-    )
-    return "".join(segment.text for segment in segments).strip()
+    if device != "auto":
+        return transcribe_with(device)
+
+    try:
+        return transcribe_with("cuda")
+    except Exception:
+        # CTranslate2 may load CUDA successfully but fail only when the lazy
+        # segment iterator performs its first inference. Keep that work inside
+        # the fallback boundary so the standard build remains CPU-capable.
+        return transcribe_with("cpu")

--- a/tool/voice_trigger.py
+++ b/tool/voice_trigger.py
@@ -9,7 +9,11 @@ import numpy as np
 import sounddevice as sd
 from pynput import keyboard
 
-from tool.audio_devices import resolve_audio_input_device
+from tool.audio_devices import (
+    audio_backend_access,
+    resolve_audio_input_device,
+    set_audio_capture_active,
+)
 from tool.config import get_cache_dir
 from tool.runtime_logging import get_logger
 from tool.stt import transcribe_full
@@ -31,6 +35,7 @@ class AudioRecorder:
         self.channels = channels
         self.input_device = input_device
         self._stream: Optional[sd.InputStream] = None
+        self._stream_active = False
         self._frames = []
         self._lock = threading.Lock()
 
@@ -43,29 +48,33 @@ class AudioRecorder:
     def start(self) -> None:
         with self._lock:
             self._frames = []
-        device_index = resolve_audio_input_device(self.input_device)
-        self._stream = sd.InputStream(
-            device=device_index,
-            samplerate=self.samplerate,
-            channels=self.channels,
-            dtype="int16",
-            callback=self._callback,
-        )
-        self._stream.start()
-        selected = sd.query_devices(
-            device_index,
-            kind="input",
-        )
+        with audio_backend_access():
+            device_index = resolve_audio_input_device(self.input_device)
+            selected = sd.query_devices(
+                device_index,
+                kind="input",
+            )
+            stream = sd.InputStream(
+                device=device_index,
+                samplerate=self.samplerate,
+                channels=self.channels,
+                dtype="int16",
+                callback=self._callback,
+            )
+            try:
+                stream.start()
+            except Exception:
+                stream.close()
+                raise
+            self._stream = stream
+            self._stream_active = True
+            set_audio_capture_active(True)
         logger.info("录音开始 | 输入设备=%s", selected["name"])
 
     def stop_and_save(self, wav_path: str) -> Optional[str]:
         if self._stream is None:
             return None
-        try:
-            self._stream.stop()
-            self._stream.close()
-        finally:
-            self._stream = None
+        self.close()
         with self._lock:
             if not self._frames:
                 logger.warning("没有录到有效音频")
@@ -83,6 +92,22 @@ class AudioRecorder:
         except Exception as exc:
             logger.exception("保存 WAV 失败")
             return None
+
+    def close(self) -> None:
+        stream = self._stream
+        if stream is None:
+            return
+        with audio_backend_access():
+            try:
+                try:
+                    stream.stop()
+                finally:
+                    stream.close()
+            finally:
+                self._stream = None
+                if self._stream_active:
+                    self._stream_active = False
+                    set_audio_capture_active(False)
 
 
 class CapslockVoiceTrigger:
@@ -136,6 +161,12 @@ class CapslockVoiceTrigger:
         logger.info("CapsLock 语音触发已启动")
 
     def stop(self) -> None:
+        if self._hold_timer is not None:
+            self._hold_timer.cancel()
+            self._hold_timer = None
+        self._caps_pressed = False
+        self._recording = False
+        self._recorder.close()
         if self._listener is not None:
             self._listener.stop()
             self._listener = None

--- a/ui/settings_dialog.py
+++ b/ui/settings_dialog.py
@@ -848,6 +848,15 @@ class SettingsDialog(QDialog):
         form.addRow(label, field)
         self._form_labels.setdefault(key, []).append(label)
 
+    def _set_form_labels_enabled(
+        self,
+        keys: tuple[str, ...],
+        enabled: bool,
+    ) -> None:
+        for key in keys:
+            for label in self._form_labels.get(key, ()):
+                label.setEnabled(enabled)
+
     def _build_models_tab(self) -> QWidget:
         page = QWidget()
         layout = QVBoxLayout(page)
@@ -1983,27 +1992,42 @@ class SettingsDialog(QDialog):
     def _set_tts_path_controls(self, *, downloading: bool) -> None:
         enabled = self.tts_enabled.isChecked()
         autodl = self.tts_backend.currentData() == "autodl"
-        self.tts_backend.setEnabled(enabled and not downloading)
-        self.tts_url.setEnabled(enabled and not autodl and not downloading)
-        self.tts_engine_root.setEnabled(
-            enabled and not autodl and not downloading
-        )
-        self.tts_engine_browse.setEnabled(
-            enabled and not autodl and not downloading
-        )
-        self.tts_model_dir.setEnabled(
-            enabled and not autodl and not downloading
-        )
-        self.tts_model_browse.setEnabled(
-            enabled and not autodl and not downloading
-        )
+        controls_enabled = enabled and not downloading
+        local_enabled = controls_enabled and not autodl
+        autodl_enabled = controls_enabled and autodl
+
+        self.tts_backend.setEnabled(controls_enabled)
+        self.tts_timeout.setEnabled(controls_enabled)
+        self.tts_url.setEnabled(local_enabled)
+        self.tts_engine_root.setEnabled(local_enabled)
+        self.tts_engine_browse.setEnabled(local_enabled)
+        self.tts_model_dir.setEnabled(local_enabled)
+        self.tts_model_browse.setEnabled(local_enabled)
         for field in (
             self.tts_autodl_ssh_command,
             self.tts_autodl_password,
             self.tts_autodl_remote_command,
             self.tts_autodl_reference_root,
         ):
-            field.setEnabled(enabled and autodl and not downloading)
+            field.setEnabled(autodl_enabled)
+
+        self._set_form_labels_enabled(
+            ("tts_backend", "tts_timeout"),
+            controls_enabled,
+        )
+        self._set_form_labels_enabled(
+            ("tts_endpoint", "tts_engine_root", "tts_model_dir"),
+            local_enabled,
+        )
+        self._set_form_labels_enabled(
+            (
+                "tts_autodl_ssh_command",
+                "tts_autodl_password",
+                "tts_autodl_remote_command",
+                "tts_autodl_reference_root",
+            ),
+            autodl_enabled,
+        )
 
     def _update_tts_state(self) -> None:
         if not hasattr(self, "tts_status"):

--- a/ui/settings_dialog.py
+++ b/ui/settings_dialog.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from pydantic import ValidationError
-from PyQt5.QtCore import QThread, QTimer, pyqtSignal
+from PyQt5.QtCore import Qt, QThread, QTimer, pyqtSignal
 from PyQt5.QtWidgets import (
     QApplication,
     QCheckBox,
@@ -26,6 +26,7 @@ from PyQt5.QtWidgets import (
     QSpinBox,
     QStackedWidget,
     QTabWidget,
+    QToolButton,
     QVBoxLayout,
     QWidget,
 )
@@ -38,8 +39,7 @@ from classes.download_manager import (
 )
 from tool.audio_devices import (
     decode_audio_input_device,
-    default_audio_input_device,
-    list_audio_input_devices,
+    refresh_audio_input_devices,
 )
 from tool.backends import create_backend, create_vision_backend
 from tool.cache import clear_runtime_cache
@@ -248,6 +248,11 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "stt_input_default_unknown": "System default input",
         "stt_input_unavailable": "Unavailable: {device}",
         "stt_device": "STT device",
+        "stt_device_auto": "Auto",
+        "stt_device_cuda": (
+            "CUDA (requires the AIpet-with-cuda build; unavailable otherwise)"
+        ),
+        "stt_device_cpu": "CPU",
         "whisper_download": "Download model",
         "whisper_disabled": (
             "Enable speech input to check the selected download directory."
@@ -281,6 +286,21 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         ),
         "download_path_invalid": "The selected directory cannot be used: {message}",
         "automation_group": "Idle behavior and memory",
+        "settings_help": "Explain these settings",
+        "automation_help_title": "Idle behavior and memory",
+        "automation_help_body": (
+            "Thinking reminder: after this much inactivity, the character may "
+            "gently check whether you are still there. It triggers at most "
+            "once per idle period.\n\n"
+            "Away reminder: after the longer inactivity threshold, the "
+            "character treats you as away. When you return, she may welcome "
+            "you back. This value must be greater than the thinking reminder."
+            "\n\n"
+            "Conversation memory: the maximum number of recent messages kept "
+            "and supplied as conversation context.\n\n"
+            "Do not disturb: disables proactive idle and return messages; "
+            "manual conversation still works."
+        ),
         "do_not_disturb": "Do not disturb",
         "clear_history": "Clear conversation history…",
         "clear_history_confirm_title": "Clear conversation history?",
@@ -309,6 +329,16 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
             "folders are still in use or could not be removed."
         ),
         "display_group": "Screen and portrait",
+        "display_help_title": "Screen and portrait",
+        "display_help_body": (
+            "Screen index: the zero-based position in Windows' current screen "
+            "list. If the index is unavailable, the primary screen is used."
+            "\n\n"
+            "Portrait height ratio: the character's target height as a share "
+            "of the selected screen's available height.\n\n"
+            "Live diagnostic console: opens a live log window for diagnosing "
+            "model, TTS, recording, and other runtime problems."
+        ),
         "screen_index": "Screen index",
         "portrait_ratio": "Portrait height ratio",
         "show_log_console": "Open live diagnostic console",
@@ -507,6 +537,11 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "stt_input_default_unknown": "系统默认输入设备",
         "stt_input_unavailable": "当前不可用：{device}",
         "stt_device": "语音识别设备",
+        "stt_device_auto": "自动",
+        "stt_device_cuda": (
+            "CUDA（请使用 AIpet-with-cuda 版本，否则无法使用）"
+        ),
+        "stt_device_cpu": "CPU",
         "whisper_download": "下载模型",
         "whisper_disabled": "启用语音输入后，将检查填写的模型下载目录。",
         "whisper_checking": "正在检查填写的模型目录……",
@@ -527,6 +562,16 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "whisper_path_required": "请先选择 Whisper 模型下载目录。",
         "download_path_invalid": "无法使用所选目录：{message}",
         "automation_group": "空闲行为与记忆",
+        "settings_help": "解释这些设置",
+        "automation_help_title": "空闲行为与记忆说明",
+        "automation_help_body": (
+            "思考提醒：持续无操作达到该时间后，角色可能会温和地询问你是否还在。"
+            "每段空闲期间最多触发一次。\n\n"
+            "离开提醒：持续无操作达到更长的时间后，角色会认为你暂时离开；"
+            "检测到你回来后，可能会欢迎你。该时间必须大于思考提醒。\n\n"
+            "对话记忆：最多保留并作为对话上下文发送的最近消息数量。\n\n"
+            "勿扰模式：停止主动的空闲提醒和回来问候，但手动对话仍可正常使用。"
+        ),
         "do_not_disturb": "勿扰模式",
         "clear_history": "清除历史对话…",
         "clear_history_confirm_title": "确定清除历史对话？",
@@ -552,6 +597,14 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
             "正在使用或无法删除的文件或文件夹。"
         ),
         "display_group": "屏幕与立绘",
+        "display_help_title": "屏幕与立绘说明",
+        "display_help_body": (
+            "屏幕编号：当前 Windows 屏幕列表中从 0 开始的序号。"
+            "序号不可用时会回退到主屏幕。\n\n"
+            "立绘高度比例：角色立绘相对于所选屏幕可用高度的目标比例。\n\n"
+            "实时日志命令行：打开实时日志窗口，用于排查模型、TTS、录音及"
+            "其他运行问题。"
+        ),
         "screen_index": "屏幕编号",
         "portrait_ratio": "立绘高度比例",
         "show_log_console": "打开实时日志命令行",
@@ -734,6 +787,7 @@ class SettingsDialog(QDialog):
         parent=None,
     ):
         super().__init__(parent)
+        self.setWindowFlag(Qt.WindowContextHelpButtonHint, False)
         self._original = settings.model_copy(deep=True)
         self._first_run = first_run
         self._model_worker: ModelListWorker | None = None
@@ -755,6 +809,8 @@ class SettingsDialog(QDialog):
             QApplication.instance()
         )
         self._form_labels: dict[str, list[QLabel]] = {}
+        self._form_fields: dict[str, list[QWidget]] = {}
+        self._audio_device_signature: tuple[object, ...] | None = None
         self._status_key: str | None = None
         self._status_values: dict[str, object] = {}
         self._whisper_status_key = "whisper_disabled"
@@ -794,6 +850,11 @@ class SettingsDialog(QDialog):
         self.buttons.rejected.connect(self.reject)
         root.addWidget(self.buttons)
 
+        self._audio_device_refresh_timer = QTimer(self)
+        self._audio_device_refresh_timer.setInterval(2_000)
+        self._audio_device_refresh_timer.timeout.connect(
+            self._refresh_audio_input_devices
+        )
         self._load_values(settings)
         self.language_combo.currentIndexChanged.connect(
             self._on_language_changed
@@ -832,10 +893,16 @@ class SettingsDialog(QDialog):
 
     def showEvent(self, event) -> None:
         super().showEvent(event)
+        self._refresh_audio_input_devices()
+        self._audio_device_refresh_timer.start()
         if self._auto_models_requested:
             return
         self._auto_models_requested = True
         QTimer.singleShot(0, self._auto_fetch_models)
+
+    def hideEvent(self, event) -> None:
+        self._audio_device_refresh_timer.stop()
+        super().hideEvent(event)
 
     def _add_row(
         self,
@@ -847,6 +914,7 @@ class SettingsDialog(QDialog):
         label.setWordWrap(True)
         form.addRow(label, field)
         self._form_labels.setdefault(key, []).append(label)
+        self._form_fields.setdefault(key, []).append(field)
 
     def _set_form_labels_enabled(
         self,
@@ -856,6 +924,39 @@ class SettingsDialog(QDialog):
         for key in keys:
             for label in self._form_labels.get(key, ()):
                 label.setEnabled(enabled)
+
+    def _set_form_rows_visible(
+        self,
+        keys: tuple[str, ...],
+        visible: bool,
+    ) -> None:
+        for key in keys:
+            for label in self._form_labels.get(key, ()):
+                label.setVisible(visible)
+            for field in self._form_fields.get(key, ()):
+                field.setVisible(visible)
+
+    def _help_button(self, title_key: str, body_key: str) -> QToolButton:
+        button = QToolButton()
+        button.setText("?")
+        button.setFixedSize(24, 24)
+        button.clicked.connect(
+            lambda: QMessageBox.information(
+                self,
+                self._text(title_key),
+                self._text(body_key),
+            )
+        )
+        return button
+
+    @staticmethod
+    def _right_aligned_widget(widget: QWidget) -> QWidget:
+        container = QWidget()
+        layout = QHBoxLayout(container)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addStretch(1)
+        layout.addWidget(widget)
+        return container
 
     def _build_models_tab(self) -> QWidget:
         page = QWidget()
@@ -1123,16 +1224,14 @@ class SettingsDialog(QDialog):
             self._browse_whisper_model
         )
         self.stt_device = QComboBox()
-        self.stt_device.addItems(["auto", "cuda", "cpu"])
+        self.stt_device.addItem("", "auto")
+        self.stt_device.addItem("", "cuda")
+        self.stt_device.addItem("", "cpu")
         self.stt_input_device = QComboBox()
-        self._default_audio_input = default_audio_input_device()
+        self._default_audio_input = None
         self._missing_audio_input_identifier = ""
         self.stt_input_device.addItem("", "")
-        for input_device in list_audio_input_devices():
-            self.stt_input_device.addItem(
-                input_device.display_name,
-                input_device.identifier,
-            )
+        self._refresh_audio_input_devices(force=True)
         self.whisper_status = QLabel()
         self.whisper_status.setWordWrap(True)
         self.whisper_progress = QProgressBar()
@@ -1281,6 +1380,13 @@ class SettingsDialog(QDialog):
         layout = QVBoxLayout(page)
         self.automation_group = QGroupBox()
         behavior_form = QFormLayout(self.automation_group)
+        self.automation_help_button = self._help_button(
+            "automation_help_title",
+            "automation_help_body",
+        )
+        behavior_form.addRow(
+            self._right_aligned_widget(self.automation_help_button)
+        )
         self.thinking_minutes = self._spinbox(1, 1_440)
         self.away_minutes = self._spinbox(2, 1_440)
         self.history_limit = self._spinbox(4, 200)
@@ -1306,6 +1412,13 @@ class SettingsDialog(QDialog):
         layout = QVBoxLayout(page)
         self.display_group = QGroupBox()
         display_form = QFormLayout(self.display_group)
+        self.display_help_button = self._help_button(
+            "display_help_title",
+            "display_help_body",
+        )
+        display_form.addRow(
+            self._right_aligned_widget(self.display_help_button)
+        )
         self.screen_index = self._spinbox(0, 32)
         self.portrait_ratio = QDoubleSpinBox()
         self.portrait_ratio.setRange(0.2, 1.0)
@@ -1492,7 +1605,7 @@ class SettingsDialog(QDialog):
         self._set_editable_combo(self.stt_model, settings.stt.model)
         self.whisper_model_dir.setText(settings.stt.model_dir)
         self._set_audio_input_device(settings.stt.input_device)
-        self.stt_device.setCurrentText(settings.stt.device)
+        self._set_combo_data(self.stt_device, settings.stt.device)
         self.screen_index.setValue(settings.display.screen_index)
         self.portrait_ratio.setValue(
             settings.display.portrait_screen_ratio
@@ -1522,6 +1635,43 @@ class SettingsDialog(QDialog):
             self._missing_audio_input_identifier = identifier
             index = self.stt_input_device.count() - 1
         self.stt_input_device.setCurrentIndex(max(index, 0))
+
+    def _refresh_audio_input_devices(self, force: bool = False) -> None:
+        if not hasattr(self, "stt_input_device"):
+            return
+        default_device, input_devices = refresh_audio_input_devices()
+        signature: tuple[object, ...] = (
+            (
+                default_device.identifier,
+                default_device.display_name,
+            )
+            if default_device is not None
+            else None,
+            tuple(
+                (device.identifier, device.display_name)
+                for device in input_devices
+            ),
+        )
+        if not force and signature == self._audio_device_signature:
+            return
+
+        selected = self.stt_input_device.currentData() or ""
+        self._audio_device_signature = signature
+        self._default_audio_input = default_device
+        self._missing_audio_input_identifier = ""
+        self.stt_input_device.blockSignals(True)
+        try:
+            self.stt_input_device.clear()
+            self.stt_input_device.addItem("", "")
+            for input_device in input_devices:
+                self.stt_input_device.addItem(
+                    input_device.display_name,
+                    input_device.identifier,
+                )
+            self._set_audio_input_device(selected)
+            self._retranslate_audio_input_devices()
+        finally:
+            self.stt_input_device.blockSignals(False)
 
     def _retranslate_audio_input_devices(self) -> None:
         default_name = (
@@ -1647,6 +1797,14 @@ class SettingsDialog(QDialog):
 
         self.deepseek_thinking.setText(self._text("deepseek_thinking"))
         self.do_not_disturb.setText(self._text("do_not_disturb"))
+        self.automation_help_button.setToolTip(self._text("settings_help"))
+        self.automation_help_button.setAccessibleName(
+            self._text("settings_help")
+        )
+        self.display_help_button.setToolTip(self._text("settings_help"))
+        self.display_help_button.setAccessibleName(
+            self._text("settings_help")
+        )
         self.clear_history_button.setText(self._text("clear_history"))
         self.clear_history_button.setToolTip(
             (
@@ -1684,6 +1842,21 @@ class SettingsDialog(QDialog):
         self._render_tts_service_button()
         self.stt_enabled.setText(self._text("stt_enabled"))
         self._retranslate_audio_input_devices()
+        self._set_combo_item_text(
+            self.stt_device,
+            "auto",
+            self._text("stt_device_auto"),
+        )
+        self._set_combo_item_text(
+            self.stt_device,
+            "cuda",
+            self._text("stt_device_cuda"),
+        )
+        self._set_combo_item_text(
+            self.stt_device,
+            "cpu",
+            self._text("stt_device_cpu"),
+        )
         self.whisper_download_button.setText(
             self._text("whisper_download")
         )
@@ -1995,6 +2168,17 @@ class SettingsDialog(QDialog):
         controls_enabled = enabled and not downloading
         local_enabled = controls_enabled and not autodl
         autodl_enabled = controls_enabled and autodl
+        local_keys = (
+            "tts_endpoint",
+            "tts_engine_root",
+            "tts_model_dir",
+        )
+        autodl_keys = (
+            "tts_autodl_ssh_command",
+            "tts_autodl_password",
+            "tts_autodl_remote_command",
+            "tts_autodl_reference_root",
+        )
 
         self.tts_backend.setEnabled(controls_enabled)
         self.tts_timeout.setEnabled(controls_enabled)
@@ -2011,21 +2195,23 @@ class SettingsDialog(QDialog):
         ):
             field.setEnabled(autodl_enabled)
 
+        self._set_form_rows_visible(local_keys, not autodl)
+        self._set_form_rows_visible(autodl_keys, autodl)
+        self.tts_download_button.setVisible(not autodl)
+        if autodl:
+            self.tts_progress.hide()
+            self.tts_extract_progress.hide()
+
         self._set_form_labels_enabled(
             ("tts_backend", "tts_timeout"),
             controls_enabled,
         )
         self._set_form_labels_enabled(
-            ("tts_endpoint", "tts_engine_root", "tts_model_dir"),
+            local_keys,
             local_enabled,
         )
         self._set_form_labels_enabled(
-            (
-                "tts_autodl_ssh_command",
-                "tts_autodl_password",
-                "tts_autodl_remote_command",
-                "tts_autodl_reference_root",
-            ),
+            autodl_keys,
             autodl_enabled,
         )
 
@@ -2777,7 +2963,7 @@ class SettingsDialog(QDialog):
                 enabled=self.stt_enabled.isChecked(),
                 model=self.stt_model.currentText().strip(),
                 model_dir=self.whisper_model_dir.text().strip(),
-                device=self.stt_device.currentText(),
+                device=self.stt_device.currentData(),
                 input_device=self.stt_input_device.currentData() or "",
             ),
             character=CharacterSettings(


### PR DESCRIPTION
## 概述

本次更新完善 TTS/STT 设置体验、录音设备热插拔支持和运行时日志，并新增标准版与 CUDA 版 Windows 单文件构建。

## 主要变更

### TTS 设置

- 关闭 TTS 后，将所有相关选项和标签统一灰置。
- 本地 TTS 仅显示本地地址、引擎目录和模型目录。
- AutoDL 云端 TTS 仅显示 SSH、密码、远端命令和远端参考音频路径。
- 隐藏当前后端不需要的下载按钮和进度信息。

### 录音与语音识别

- 设置窗口打开期间实时刷新录音设备，新接入设备无需重启程序。
- 刷新 PortAudio 时避开正在进行的录音，防止设备重载与录音流争抢。
- 完善录音流停止、关闭及程序退出时的资源清理。
- 修正 Whisper 自动模式：CUDA 延迟推理失败时能够回退 CPU。
- 为 CUDA 选项增加提示，注明必须使用 `AIpet-with-cuda` 版本。

### 设置帮助与日志

- 为“空闲行为与记忆”和“屏幕与立绘”增加页面内问号说明。
- 移除未配置帮助内容的窗口标题栏问号。
- 即使关闭实时日志查看窗口，仍持续写入每日诊断日志。
- 增加语音模块加载和触发器启动异常日志。

### Windows 打包

- 生成两个单文件版本：
  - `AIpet.exe`：标准 CPU 版。
  - `AIpet-with-cuda.exe`：附带 CUDA 12 cuBLAS、cuDNN 9 和 NVRTC。
- 构建环境排除 PyTorch、Transformers 等不需要的大型依赖。
- 修正 PyQt5 与 CTranslate2 的 MSVC 运行库冲突。
- 输出构建文件大小和 SHA256。

## 验证

- 完整测试：83 项全部通过。
- `git diff --check` 通过。
- 标准版与 CUDA 版启动冒烟测试通过。
- 标准版确认不包含 CUDA DLL。
- CUDA 版确认包含 12 个 cuBLAS、cuDNN 和 NVRTC DLL。
- 在 RTX 5070 Ti 上完成真实 Whisper CUDA 推理。

## 构建产物

- `AIpet.exe`：193.7 MiB
- `AIpet-with-cuda.exe`：1089.9 MiB

构建产物位于 `dist/`，不会提交到 Git 仓库。