### PR TITLE
Add macOS adaptation for upstream V2.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,13 +29,9 @@ history.json
 .ssh/
 
 # Runtime output
-build/
-dist/
 models/
 tmp/
 voices/*.wav
 cache/
 *.log
-_tmp_*
 .native_overlay/
-.cache/

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ voices/*.wav
 cache/
 *.log
 _tmp_*
+.native_overlay/
+.cache/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 <p align="center">
   <img alt="Python 3.10+" src="https://img.shields.io/badge/Python-3.10%2B-3776AB?style=flat-square&logo=python&logoColor=white">
   <img alt="Windows" src="https://img.shields.io/badge/Platform-Windows-0078D4?style=flat-square&logo=windows11&logoColor=white">
+  <img alt="macOS" src="https://img.shields.io/badge/Platform-macOS-000000?style=flat-square&logo=apple&logoColor=white">
   <img alt="PyQt5" src="https://img.shields.io/badge/UI-PyQt5-41CD52?style=flat-square&logo=qt&logoColor=white">
   <img alt="Ollama" src="https://img.shields.io/badge/Local-Ollama-111111?style=flat-square&logo=ollama&logoColor=white">
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/github/license/kuxiaowo/AIpet-Murasame?style=flat-square&color=8A2BE2"></a>
@@ -34,9 +35,11 @@ her—and the maintainer—very happy.
 
 ## Overview
 
-AIpet is an always-on-top Murasame desktop companion for Windows. It combines a
-transparent PyQt5 character window with local or cloud conversations, optional
-screen awareness, GPT-SoVITS speech output, and faster-whisper speech input.
+AIpet is an always-on-top Murasame desktop companion for Windows and Apple
+Silicon macOS. It combines a transparent PyQt5 character window with local or
+cloud conversations, optional screen awareness, GPT-SoVITS speech output, and
+faster-whisper speech input. This edition keeps the upstream V2 interface and
+behavior while adding native macOS integration.
 
 Based on [LemonQu-GIT/MurasamePet](https://github.com/LemonQu-GIT/MurasamePet).
 Videos and project updates are available on
@@ -52,12 +55,13 @@ Videos and project updates are available on
 - Hold-to-talk speech input powered by faster-whisper
 - Conversation memory, screen-event summaries, proactive reminders, and a
   persistent Do Not Disturb mode
-- Transparent multi-monitor window, Windows topmost watchdog, bilingual
-  settings, and structured diagnostic logs
+- Transparent multi-monitor window, Windows topmost watchdog, native macOS
+  fullscreen Spaces and input-method support, bilingual settings, and
+  structured diagnostic logs
 
 ## Quick start
 
-Windows 10 and Windows 11 are the primary supported systems.
+Windows 10/11 and Apple Silicon macOS are supported.
 
 ### Run the Windows EXE
 
@@ -104,6 +108,32 @@ To enable speech input in a source installation:
 python -m pip install -r requirements-voice.txt
 ```
 
+### Run on macOS
+
+Requirements:
+
+- Apple Silicon Mac
+- Python 3.10 or later
+- Xcode Command Line Tools (`xcode-select --install`)
+
+Double-click **`start_macos.command`**, or run:
+
+```zsh
+./start_macos.command
+```
+
+The first launch creates `.venv`, installs the application and speech-input
+dependencies, and compiles the small native fullscreen helper. macOS may ask
+for these permissions:
+
+- **Screen Recording** for Screen Vision
+- **Microphone** for speech input
+- **Accessibility / Input Monitoring** for the macOS Option+V hold-to-talk trigger
+
+The native helper appears only while another application occupies a fullscreen
+Space. It preserves the original character interaction and supports macOS
+Pinyin composition and candidate selection in fullscreen.
+
 ### Configure a conversation backend
 
 AIpet needs either a local Ollama service or a cloud API.
@@ -124,6 +154,8 @@ $env:DASHSCOPE_API_KEY = "your-key"
 $env:OPENAI_API_KEY = "your-key"
 ```
 
+On macOS, use the equivalent `export NAME="value"` syntax in Terminal.
+
 On first launch, select the backend and model, set the user name, review the
 personality prompt, and save. Keep vision, TTS, and speech input disabled until
 their dependencies are ready.
@@ -133,13 +165,16 @@ their dependencies are ready.
 | Capability | Setup |
 |---|---|
 | Screen awareness | Enable **Screen Vision** and choose an Ollama, Alibaba Cloud, or OpenAI-compatible vision model. Screenshots are temporary and are not added to conversation history. |
-| Local TTS | Enable **TTS → Local computer** and select the GPT-SoVITS engine and Murasame voice-model directories. Missing managed assets can be downloaded after confirmation. |
+| Local TTS | Enable **TTS → Local computer**. On macOS, click **Install GPT-SoVITS for macOS** in Settings; the installer places the official engine and base models in the project and keeps its Conda environment under `~/.local/share/AIpet-Murasame/`. Then click **Download voice model** for Murasame's weights and references. |
 | AutoDL TTS | Enable **TTS → AutoDL cloud**, provide the SSH login, password, remote command, and reference-voice directory. The remote instance must already expose GPT-SoVITS on port `9880`. |
-| Speech input | Enable speech input, choose a microphone, device, and faster-whisper model. Hold Caps Lock for two seconds to record; release it to transcribe and send. |
+| Speech input | On Windows, enable speech input, choose a microphone, device, and faster-whisper model, then hold Caps Lock for two seconds to record. On macOS, hold Option+V for two seconds instead. |
 
 TTS errors do not discard text replies. Temporary screenshots, recordings, and
 generated speech are cleaned automatically and can also be cleared from
 Settings.
+
+For a macOS GPT-SoVITS environment outside the engine directory, set
+`AIPET_GPT_SOVITS_PYTHON` to that environment's Python executable.
 
 ## Controls
 
@@ -149,10 +184,11 @@ Settings.
 | Cancel input | Press Escape |
 | Pat her head | Hold the left mouse button over her head and move horizontally |
 | Move the pet | Drag with the middle mouse button |
-| Talk | Hold Caps Lock for two seconds when speech input is enabled |
+| Talk | On Windows, hold Caps Lock for two seconds; on macOS, hold Option+V for two seconds |
 | Settings, vision, DND, memory, exit | Use the system tray menu |
 
 Dragging the pet to another monitor updates its display and portrait scale.
+The same controls remain available in the native macOS fullscreen window.
 
 ## Data and privacy
 
@@ -171,6 +207,11 @@ Disposable runtime data is stored under
 `%LOCALAPPDATA%\AIpet-Murasame\cache\`. Downloaded models use
 `C:\AIpet\models\` by default; set `AIPET_MODEL_DIR` to override that location.
 
+On macOS, persistent data and logs are stored under
+`~/.config/AIpet-Murasame/`, runtime cache under its `cache/` subdirectory,
+and downloaded models in the repository's `models/` directory by default.
+AutoDL passwords are stored in macOS Keychain.
+
 API keys entered in Settings are stored in `config.json`. Leave those fields
 blank and use environment variables if you prefer to keep keys out of the
 configuration file. Logs redact recognized secret fields and replace large
@@ -183,6 +224,12 @@ Run the test suite in the `aipet` Conda environment:
 ```powershell
 $env:QT_QPA_PLATFORM = "offscreen"
 python -m unittest discover -s tests -v
+```
+
+On macOS:
+
+```zsh
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m unittest discover -s tests -v
 ```
 
 Build both single-file Windows executables with:
@@ -221,14 +268,17 @@ Main project areas:
 classes\    desktop interaction, workers, and downloads
 tool\       backends, configuration, storage, speech, and diagnostics
 ui\         bilingual settings window
+native_overlay/  native macOS fullscreen and input bridge
 packaging\  reproducible PyInstaller build
 tests\      unit and UI smoke tests
 ```
 
 ## Limitations
 
-- Desktop behavior is designed and tested primarily for Windows.
 - Exclusive-fullscreen or anti-cheat-protected surfaces may cover the pet.
+- The macOS helper targets Apple Silicon and is compiled locally on first run.
+- faster-whisper runs on CPU on Apple Silicon; its CUDA mode is for compatible
+  Windows/NVIDIA systems.
 - Local chat, vision, and TTS performance depends on the selected model and
   hardware.
 - Character artwork and voice assets may have terms different from the source
@@ -238,6 +288,8 @@ tests\      unit and UI smoke tests
 
 - Original desktop-pet project:
   [LemonQu-GIT/MurasamePet](https://github.com/LemonQu-GIT/MurasamePet)
+- Upstream AIpet V2 project and Windows implementation:
+  [kuxiaowo/AIpet-Murasame](https://github.com/kuxiaowo/AIpet-Murasame)
 - Speech-synthesis project:
   [RVC-Boss/GPT-SoVITS](https://github.com/RVC-Boss/GPT-SoVITS)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@
 
 <p align="center">
   <a href="https://github.com/kuxiaowo/AIpet-Murasame/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/kuxiaowo/AIpet-Murasame?style=flat-square&logo=github"></a>
-  <a href="https://space.bilibili.com/1067030066"><img alt="Bilibili" src="https://img.shields.io/badge/Bilibili-Video%20guides-00A1D6?style=flat-square&logo=bilibili&logoColor=white"></a>
 </p>
 
 <p align="center">
@@ -32,8 +31,7 @@
 > Spaces compatibility, macOS input-method support, and local macOS TTS setup.
 
 If you enjoy having Murasame on your desktop, please leave a
-[Star ⭐](https://github.com/kuxiaowo/AIpet-Murasame/stargazers) or follow the
-project on [Bilibili](https://space.bilibili.com/1067030066). It would make
+[Star ⭐](https://github.com/kuxiaowo/AIpet-Murasame/stargazers). It would make
 her—and the maintainer—very happy.
 
 ## Overview
@@ -45,8 +43,6 @@ input. It keeps the upstream V2 interface and behavior while adding native
 macOS integration.
 
 Based on [LemonQu-GIT/MurasamePet](https://github.com/LemonQu-GIT/MurasamePet).
-Videos and project updates are available on
-[Bilibili](https://space.bilibili.com/1067030066).
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
   <img src="icon.png" width="112" alt="AIpet icon">
 </p>
 
-<h1 align="center">AIpet · Murasame for macOS</h1>
+<h1 align="center">AIpet · Murasame</h1>
 
 <p align="center">
-  <strong>An Apple Silicon macOS adaptation of the AIpet-Murasame desktop companion.</strong>
+  <strong>A prompt-driven AI desktop companion with interchangeable local and cloud models.</strong>
 </p>
 
 <p align="center">
   <img alt="Python 3.10+" src="https://img.shields.io/badge/Python-3.10%2B-3776AB?style=flat-square&logo=python&logoColor=white">
-  <img alt="macOS" src="https://img.shields.io/badge/Platform-macOS-000000?style=flat-square&logo=apple&logoColor=white">
+  <img alt="Windows" src="https://img.shields.io/badge/Platform-Windows-0078D4?style=flat-square&logo=windows11&logoColor=white">
   <img alt="PyQt5" src="https://img.shields.io/badge/UI-PyQt5-41CD52?style=flat-square&logo=qt&logoColor=white">
   <img alt="Ollama" src="https://img.shields.io/badge/Local-Ollama-111111?style=flat-square&logo=ollama&logoColor=white">
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/github/license/kuxiaowo/AIpet-Murasame?style=flat-square&color=8A2BE2"></a>
@@ -18,6 +18,7 @@
 
 <p align="center">
   <a href="https://github.com/kuxiaowo/AIpet-Murasame/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/kuxiaowo/AIpet-Murasame?style=flat-square&logo=github"></a>
+  <a href="https://space.bilibili.com/1067030066"><img alt="Bilibili" src="https://img.shields.io/badge/Bilibili-Video%20guides-00A1D6?style=flat-square&logo=bilibili&logoColor=white"></a>
 </p>
 
 <p align="center">
@@ -26,23 +27,20 @@
 
 ---
 
-> This fork is the macOS edition of AIpet-Murasame. It preserves the upstream
-> interface and behavior while adding native Apple Silicon support, fullscreen
-> Spaces compatibility, macOS input-method support, and local macOS TTS setup.
-
 If you enjoy having Murasame on your desktop, please leave a
-[Star ⭐](https://github.com/kuxiaowo/AIpet-Murasame/stargazers). It would make
+[Star ⭐](https://github.com/kuxiaowo/AIpet-Murasame/stargazers) or follow the
+project on [Bilibili](https://space.bilibili.com/1067030066). It would make
 her—and the maintainer—very happy.
 
 ## Overview
 
-This repository is an Apple Silicon macOS adaptation of AIpet-Murasame. It
-combines a transparent PyQt5 character window with local or cloud conversations,
-optional screen awareness, GPT-SoVITS speech output, and faster-whisper speech
-input. It keeps the upstream V2 interface and behavior while adding native
-macOS integration.
+AIpet is an always-on-top Murasame desktop companion for Windows. It combines a
+transparent PyQt5 character window with local or cloud conversations, optional
+screen awareness, GPT-SoVITS speech output, and faster-whisper speech input.
 
 Based on [LemonQu-GIT/MurasamePet](https://github.com/LemonQu-GIT/MurasamePet).
+Videos and project updates are available on
+[Bilibili](https://space.bilibili.com/1067030066).
 
 ## Features
 
@@ -54,40 +52,63 @@ Based on [LemonQu-GIT/MurasamePet](https://github.com/LemonQu-GIT/MurasamePet).
 - Hold-to-talk speech input powered by faster-whisper
 - Conversation memory, screen-event summaries, proactive reminders, and a
   persistent Do Not Disturb mode
-- Transparent multi-monitor window, macOS menu bar integration, native
-  fullscreen Spaces and input-method support, bilingual settings, and
-  structured diagnostic logs
+- Transparent multi-monitor window, Windows topmost watchdog, bilingual
+  settings, and structured diagnostic logs
 
 ## Quick start
 
-This fork targets Apple Silicon macOS. Windows executable packaging remains
-part of the upstream project and is not the installation path documented here.
+Windows 10 and Windows 11 are the primary supported systems.
 
-### Run on macOS
+### macOS (Apple Silicon)
 
-Requirements:
+A macOS Apple Silicon adaptation is available on the
+[Releases page](../../releases). For a source installation, run
+`start_macos.command` from the project directory.
 
-- Apple Silicon Mac
-- Python 3.10 or later
-- Xcode Command Line Tools (`xcode-select --install`)
+### Run the Windows EXE
 
-Double-click **`start_macos.command`**, or run:
+Choose one executable from the
+[Releases page](https://github.com/kuxiaowo/AIpet-Murasame/releases):
 
-```zsh
-./start_macos.command
+- **`AIpet.exe` (standard build, about 194 MiB):** does not bundle CUDA.
+  Use this build for CPU-based Whisper transcription or when local
+  speech-recognition GPU acceleration is not needed. This is the recommended
+  download if you are unsure which build to choose.
+- **`AIpet-with-cuda.exe` (CUDA build, about 1.06 GiB):** bundles CUDA 12
+  cuBLAS, cuDNN 9, and NVRTC for local faster-whisper acceleration on a
+  compatible NVIDIA GPU. A compatible NVIDIA graphics driver is still
+  required. If CUDA is selected in Settings, use this build.
+
+Both builds provide the same application features and settings interface.
+The CUDA build is larger only because it includes the GPU runtime libraries.
+
+1. Download the selected EXE. If a release has no EXE asset, use the source
+   installation below.
+2. Place it in a writable permanent directory such as `C:\AIpet\`.
+3. Double-click the downloaded EXE.
+
+The EXEs include the application and faster-whisper runtime, so Python, Conda,
+and Git are not required. Chat models, Whisper models, and GPT-SoVITS assets
+are not bundled; optional downloads begin only after confirmation in Settings.
+
+### Run from source
+
+Install [Git](https://git-scm.com/) and
+[Conda or Miniconda](https://docs.conda.io/), then run:
+
+```powershell
+git clone https://github.com/kuxiaowo/AIpet-Murasame.git
+cd AIpet-Murasame
+conda env create -f environment.yml
+conda activate aipet
+python main.py
 ```
 
-The first launch creates `.venv`, installs the application and speech-input
-dependencies, and compiles the small native fullscreen helper. macOS may ask
-for these permissions:
+To enable speech input in a source installation:
 
-- **Screen Recording** for Screen Vision
-- **Microphone** for speech input
-- **Accessibility / Input Monitoring** for the macOS Option+V hold-to-talk trigger
-
-The native helper appears only while another application occupies a fullscreen
-Space. It preserves the original character interaction and supports macOS
-Pinyin composition and candidate selection in fullscreen.
+```powershell
+python -m pip install -r requirements-voice.txt
+```
 
 ### Configure a conversation backend
 
@@ -96,20 +117,18 @@ AIpet needs either a local Ollama service or a cloud API.
 For Ollama, start the service and pull a chat model. The vision model is
 optional:
 
-```zsh
+```powershell
 ollama pull qwen3:14b
 ollama pull qwen2.5vl:7b
 ```
 
 For cloud services, enter credentials in Settings or use environment variables:
 
-```zsh
-export DEEPSEEK_API_KEY="your-key"
-export DASHSCOPE_API_KEY="your-key"
-export OPENAI_API_KEY="your-key"
+```powershell
+$env:DEEPSEEK_API_KEY = "your-key"
+$env:DASHSCOPE_API_KEY = "your-key"
+$env:OPENAI_API_KEY = "your-key"
 ```
-
-On macOS, use the equivalent `export NAME="value"` syntax in Terminal.
 
 On first launch, select the backend and model, set the user name, review the
 personality prompt, and save. Keep vision, TTS, and speech input disabled until
@@ -120,16 +139,13 @@ their dependencies are ready.
 | Capability | Setup |
 |---|---|
 | Screen awareness | Enable **Screen Vision** and choose an Ollama, Alibaba Cloud, or OpenAI-compatible vision model. Screenshots are temporary and are not added to conversation history. |
-| Local TTS | Enable **TTS → Local computer**. On macOS, click **Install GPT-SoVITS for macOS** in Settings; the installer places the official engine and base models in the project and keeps its Conda environment under `~/.local/share/AIpet-Murasame/`. Then click **Download voice model** for Murasame's weights and references. |
+| Local TTS | Enable **TTS → Local computer** and select the GPT-SoVITS engine and Murasame voice-model directories. Missing managed assets can be downloaded after confirmation. |
 | AutoDL TTS | Enable **TTS → AutoDL cloud**, provide the SSH login, password, remote command, and reference-voice directory. The remote instance must already expose GPT-SoVITS on port `9880`. |
-| Speech input | Enable speech input, choose a microphone and faster-whisper model, then hold Option+V for two seconds to record. |
+| Speech input | Enable speech input, choose a microphone, device, and faster-whisper model. Hold Caps Lock for two seconds to record; release it to transcribe and send. |
 
 TTS errors do not discard text replies. Temporary screenshots, recordings, and
 generated speech are cleaned automatically and can also be cleared from
 Settings.
-
-For a macOS GPT-SoVITS environment outside the engine directory, set
-`AIPET_GPT_SOVITS_PYTHON` to that environment's Python executable.
 
 ## Controls
 
@@ -139,18 +155,27 @@ For a macOS GPT-SoVITS environment outside the engine directory, set
 | Cancel input | Press Escape |
 | Pat her head | Hold the left mouse button over her head and move horizontally |
 | Move the pet | Drag with the middle mouse button |
-| Talk | Hold Option+V for two seconds |
+| Talk | Hold Caps Lock for two seconds when speech input is enabled |
 | Settings, vision, DND, memory, exit | Use the system tray menu |
 
 Dragging the pet to another monitor updates its display and portrait scale.
-The same controls remain available in the native macOS fullscreen window.
 
 ## Data and privacy
 
-On macOS, persistent data and logs are stored under
-`~/.config/AIpet-Murasame/`, runtime cache under its `cache/` subdirectory,
-and downloaded models in the repository's `models/` directory by default.
-AutoDL passwords are stored in macOS Keychain.
+On Windows, settings and persistent state are stored under:
+
+```text
+%APPDATA%\AIpet-Murasame\
+├── config.json
+├── history.json
+├── screen_memory.json
+├── personality.txt
+└── logs\
+```
+
+Disposable runtime data is stored under
+`%LOCALAPPDATA%\AIpet-Murasame\cache\`. Downloaded models use
+`C:\AIpet\models\` by default; set `AIPET_MODEL_DIR` to override that location.
 
 API keys entered in Settings are stored in `config.json`. Leave those fields
 blank and use environment variables if you prefer to keep keys out of the
@@ -159,10 +184,41 @@ Base64 media with metadata.
 
 ## Development
 
-On macOS:
+Run the test suite in the `aipet` Conda environment:
 
-```zsh
-QT_QPA_PLATFORM=offscreen .venv/bin/python -m unittest discover -s tests -v
+```powershell
+$env:QT_QPA_PLATFORM = "offscreen"
+python -m unittest discover -s tests -v
+```
+
+Build both single-file Windows executables with:
+
+```powershell
+.\packaging\build_exe.ps1
+```
+
+The script creates an isolated `aipet_build_whisper` Conda environment when
+needed and writes:
+
+- `dist\AIpet.exe`: standard CPU build.
+- `dist\AIpet-with-cuda.exe`: CUDA build with the CUDA 12 cuBLAS, cuDNN 9,
+  and NVRTC runtime bundled for local Whisper GPU inference.
+
+Reuse the installed build dependencies with:
+
+```powershell
+.\packaging\build_exe.ps1 -SkipDependencyInstall
+```
+
+When skipping dependency installation, the build environment must already
+contain the CUDA 12 cuBLAS, cuDNN 9, and NVRTC DLLs. If they are outside the
+build environment's `Library\bin`, provide their locations with:
+
+```powershell
+.\packaging\build_exe.ps1 -SkipDependencyInstall `
+  -CudaDllDirectory C:\path\to\cublas\bin `
+  -CudnnDllDirectory C:\path\to\cudnn\bin `
+  -CudaNvrtcDllDirectory C:\path\to\nvrtc\bin
 ```
 
 Main project areas:
@@ -171,16 +227,14 @@ Main project areas:
 classes\    desktop interaction, workers, and downloads
 tool\       backends, configuration, storage, speech, and diagnostics
 ui\         bilingual settings window
-native_overlay/  native macOS fullscreen and input bridge
 packaging\  reproducible PyInstaller build
 tests\      unit and UI smoke tests
 ```
 
 ## Limitations
 
+- Desktop behavior is designed and tested primarily for Windows.
 - Exclusive-fullscreen or anti-cheat-protected surfaces may cover the pet.
-- The macOS helper targets Apple Silicon and is compiled locally on first run.
-- faster-whisper runs on CPU on Apple Silicon.
 - Local chat, vision, and TTS performance depends on the selected model and
   hardware.
 - Character artwork and voice assets may have terms different from the source
@@ -190,8 +244,6 @@ tests\      unit and UI smoke tests
 
 - Original desktop-pet project:
   [LemonQu-GIT/MurasamePet](https://github.com/LemonQu-GIT/MurasamePet)
-- Upstream AIpet V2 project:
-  [kuxiaowo/AIpet-Murasame](https://github.com/kuxiaowo/AIpet-Murasame)
 - Speech-synthesis project:
   [RVC-Boss/GPT-SoVITS](https://github.com/RVC-Boss/GPT-SoVITS)
 
@@ -202,3 +254,4 @@ This is an unofficial fan project for study and technical exchange. Murasame
 and the included third-party artwork, voice data, and related assets belong to
 their respective rights holders, including YUZUSOFT, and are not relicensed by
 the AGPL. Do not use those assets commercially without permission.
+

--- a/README.md
+++ b/README.md
@@ -2,15 +2,14 @@
   <img src="icon.png" width="112" alt="AIpet icon">
 </p>
 
-<h1 align="center">AIpet · Murasame</h1>
+<h1 align="center">AIpet · Murasame for macOS</h1>
 
 <p align="center">
-  <strong>A prompt-driven AI desktop companion with interchangeable local and cloud models.</strong>
+  <strong>An Apple Silicon macOS adaptation of the AIpet-Murasame desktop companion.</strong>
 </p>
 
 <p align="center">
   <img alt="Python 3.10+" src="https://img.shields.io/badge/Python-3.10%2B-3776AB?style=flat-square&logo=python&logoColor=white">
-  <img alt="Windows" src="https://img.shields.io/badge/Platform-Windows-0078D4?style=flat-square&logo=windows11&logoColor=white">
   <img alt="macOS" src="https://img.shields.io/badge/Platform-macOS-000000?style=flat-square&logo=apple&logoColor=white">
   <img alt="PyQt5" src="https://img.shields.io/badge/UI-PyQt5-41CD52?style=flat-square&logo=qt&logoColor=white">
   <img alt="Ollama" src="https://img.shields.io/badge/Local-Ollama-111111?style=flat-square&logo=ollama&logoColor=white">
@@ -28,6 +27,10 @@
 
 ---
 
+> This fork is the macOS edition of AIpet-Murasame. It preserves the upstream
+> interface and behavior while adding native Apple Silicon support, fullscreen
+> Spaces compatibility, macOS input-method support, and local macOS TTS setup.
+
 If you enjoy having Murasame on your desktop, please leave a
 [Star ⭐](https://github.com/kuxiaowo/AIpet-Murasame/stargazers) or follow the
 project on [Bilibili](https://space.bilibili.com/1067030066). It would make
@@ -35,11 +38,11 @@ her—and the maintainer—very happy.
 
 ## Overview
 
-AIpet is an always-on-top Murasame desktop companion for Windows and Apple
-Silicon macOS. It combines a transparent PyQt5 character window with local or
-cloud conversations, optional screen awareness, GPT-SoVITS speech output, and
-faster-whisper speech input. This edition keeps the upstream V2 interface and
-behavior while adding native macOS integration.
+This repository is an Apple Silicon macOS adaptation of AIpet-Murasame. It
+combines a transparent PyQt5 character window with local or cloud conversations,
+optional screen awareness, GPT-SoVITS speech output, and faster-whisper speech
+input. It keeps the upstream V2 interface and behavior while adding native
+macOS integration.
 
 Based on [LemonQu-GIT/MurasamePet](https://github.com/LemonQu-GIT/MurasamePet).
 Videos and project updates are available on
@@ -55,58 +58,14 @@ Videos and project updates are available on
 - Hold-to-talk speech input powered by faster-whisper
 - Conversation memory, screen-event summaries, proactive reminders, and a
   persistent Do Not Disturb mode
-- Transparent multi-monitor window, Windows topmost watchdog, native macOS
+- Transparent multi-monitor window, macOS menu bar integration, native
   fullscreen Spaces and input-method support, bilingual settings, and
   structured diagnostic logs
 
 ## Quick start
 
-Windows 10/11 and Apple Silicon macOS are supported.
-
-### Run the Windows EXE
-
-Choose one executable from the
-[Releases page](https://github.com/kuxiaowo/AIpet-Murasame/releases):
-
-- **`AIpet.exe` (standard build, about 194 MiB):** does not bundle CUDA.
-  Use this build for CPU-based Whisper transcription or when local
-  speech-recognition GPU acceleration is not needed. This is the recommended
-  download if you are unsure which build to choose.
-- **`AIpet-with-cuda.exe` (CUDA build, about 1.06 GiB):** bundles CUDA 12
-  cuBLAS, cuDNN 9, and NVRTC for local faster-whisper acceleration on a
-  compatible NVIDIA GPU. A compatible NVIDIA graphics driver is still
-  required. If CUDA is selected in Settings, use this build.
-
-Both builds provide the same application features and settings interface.
-The CUDA build is larger only because it includes the GPU runtime libraries.
-
-1. Download the selected EXE. If a release has no EXE asset, use the source
-   installation below.
-2. Place it in a writable permanent directory such as `C:\AIpet\`.
-3. Double-click the downloaded EXE.
-
-The EXEs include the application and faster-whisper runtime, so Python, Conda,
-and Git are not required. Chat models, Whisper models, and GPT-SoVITS assets
-are not bundled; optional downloads begin only after confirmation in Settings.
-
-### Run from source
-
-Install [Git](https://git-scm.com/) and
-[Conda or Miniconda](https://docs.conda.io/), then run:
-
-```powershell
-git clone https://github.com/kuxiaowo/AIpet-Murasame.git
-cd AIpet-Murasame
-conda env create -f environment.yml
-conda activate aipet
-python main.py
-```
-
-To enable speech input in a source installation:
-
-```powershell
-python -m pip install -r requirements-voice.txt
-```
+This fork targets Apple Silicon macOS. Windows executable packaging remains
+part of the upstream project and is not the installation path documented here.
 
 ### Run on macOS
 
@@ -141,17 +100,17 @@ AIpet needs either a local Ollama service or a cloud API.
 For Ollama, start the service and pull a chat model. The vision model is
 optional:
 
-```powershell
+```zsh
 ollama pull qwen3:14b
 ollama pull qwen2.5vl:7b
 ```
 
 For cloud services, enter credentials in Settings or use environment variables:
 
-```powershell
-$env:DEEPSEEK_API_KEY = "your-key"
-$env:DASHSCOPE_API_KEY = "your-key"
-$env:OPENAI_API_KEY = "your-key"
+```zsh
+export DEEPSEEK_API_KEY="your-key"
+export DASHSCOPE_API_KEY="your-key"
+export OPENAI_API_KEY="your-key"
 ```
 
 On macOS, use the equivalent `export NAME="value"` syntax in Terminal.
@@ -167,7 +126,7 @@ their dependencies are ready.
 | Screen awareness | Enable **Screen Vision** and choose an Ollama, Alibaba Cloud, or OpenAI-compatible vision model. Screenshots are temporary and are not added to conversation history. |
 | Local TTS | Enable **TTS → Local computer**. On macOS, click **Install GPT-SoVITS for macOS** in Settings; the installer places the official engine and base models in the project and keeps its Conda environment under `~/.local/share/AIpet-Murasame/`. Then click **Download voice model** for Murasame's weights and references. |
 | AutoDL TTS | Enable **TTS → AutoDL cloud**, provide the SSH login, password, remote command, and reference-voice directory. The remote instance must already expose GPT-SoVITS on port `9880`. |
-| Speech input | On Windows, enable speech input, choose a microphone, device, and faster-whisper model, then hold Caps Lock for two seconds to record. On macOS, hold Option+V for two seconds instead. |
+| Speech input | Enable speech input, choose a microphone and faster-whisper model, then hold Option+V for two seconds to record. |
 
 TTS errors do not discard text replies. Temporary screenshots, recordings, and
 generated speech are cleaned automatically and can also be cleared from
@@ -184,28 +143,13 @@ For a macOS GPT-SoVITS environment outside the engine directory, set
 | Cancel input | Press Escape |
 | Pat her head | Hold the left mouse button over her head and move horizontally |
 | Move the pet | Drag with the middle mouse button |
-| Talk | On Windows, hold Caps Lock for two seconds; on macOS, hold Option+V for two seconds |
+| Talk | Hold Option+V for two seconds |
 | Settings, vision, DND, memory, exit | Use the system tray menu |
 
 Dragging the pet to another monitor updates its display and portrait scale.
 The same controls remain available in the native macOS fullscreen window.
 
 ## Data and privacy
-
-On Windows, settings and persistent state are stored under:
-
-```text
-%APPDATA%\AIpet-Murasame\
-├── config.json
-├── history.json
-├── screen_memory.json
-├── personality.txt
-└── logs\
-```
-
-Disposable runtime data is stored under
-`%LOCALAPPDATA%\AIpet-Murasame\cache\`. Downloaded models use
-`C:\AIpet\models\` by default; set `AIPET_MODEL_DIR` to override that location.
 
 On macOS, persistent data and logs are stored under
 `~/.config/AIpet-Murasame/`, runtime cache under its `cache/` subdirectory,
@@ -219,47 +163,10 @@ Base64 media with metadata.
 
 ## Development
 
-Run the test suite in the `aipet` Conda environment:
-
-```powershell
-$env:QT_QPA_PLATFORM = "offscreen"
-python -m unittest discover -s tests -v
-```
-
 On macOS:
 
 ```zsh
 QT_QPA_PLATFORM=offscreen .venv/bin/python -m unittest discover -s tests -v
-```
-
-Build both single-file Windows executables with:
-
-```powershell
-.\packaging\build_exe.ps1
-```
-
-The script creates an isolated `aipet_build_whisper` Conda environment when
-needed and writes:
-
-- `dist\AIpet.exe`: standard CPU build.
-- `dist\AIpet-with-cuda.exe`: CUDA build with the CUDA 12 cuBLAS, cuDNN 9,
-  and NVRTC runtime bundled for local Whisper GPU inference.
-
-Reuse the installed build dependencies with:
-
-```powershell
-.\packaging\build_exe.ps1 -SkipDependencyInstall
-```
-
-When skipping dependency installation, the build environment must already
-contain the CUDA 12 cuBLAS, cuDNN 9, and NVRTC DLLs. If they are outside the
-build environment's `Library\bin`, provide their locations with:
-
-```powershell
-.\packaging\build_exe.ps1 -SkipDependencyInstall `
-  -CudaDllDirectory C:\path\to\cublas\bin `
-  -CudnnDllDirectory C:\path\to\cudnn\bin `
-  -CudaNvrtcDllDirectory C:\path\to\nvrtc\bin
 ```
 
 Main project areas:
@@ -277,8 +184,7 @@ tests\      unit and UI smoke tests
 
 - Exclusive-fullscreen or anti-cheat-protected surfaces may cover the pet.
 - The macOS helper targets Apple Silicon and is compiled locally on first run.
-- faster-whisper runs on CPU on Apple Silicon; its CUDA mode is for compatible
-  Windows/NVIDIA systems.
+- faster-whisper runs on CPU on Apple Silicon.
 - Local chat, vision, and TTS performance depends on the selected model and
   hardware.
 - Character artwork and voice assets may have terms different from the source
@@ -288,7 +194,7 @@ tests\      unit and UI smoke tests
 
 - Original desktop-pet project:
   [LemonQu-GIT/MurasamePet](https://github.com/LemonQu-GIT/MurasamePet)
-- Upstream AIpet V2 project and Windows implementation:
+- Upstream AIpet V2 project:
   [kuxiaowo/AIpet-Murasame](https://github.com/kuxiaowo/AIpet-Murasame)
 - Speech-synthesis project:
   [RVC-Boss/GPT-SoVITS](https://github.com/RVC-Boss/GPT-SoVITS)

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ Videos and project updates are available on
 
 Windows 10 and Windows 11 are the primary supported systems.
 
-### macOS (Apple Silicon)
+### macOS (for Macs with Apple Silicon / M-series chips)
 
-A macOS Apple Silicon adaptation is available on the
+A macOS adaptation for Macs with Apple Silicon (M-series chips) is available on the
 [Releases page](../../releases). For a source installation, run
 `start_macos.command` from the project directory.
 

--- a/classes/murasame_class.py
+++ b/classes/murasame_class.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ctypes
 import sys
 import textwrap
 import time
@@ -8,7 +9,7 @@ import wave
 from pathlib import Path
 
 import cv2
-from PyQt5.QtCore import QEvent, QRect, Qt, QTimer, pyqtSignal
+from PyQt5.QtCore import QRect, Qt, QTimer, pyqtSignal
 from PyQt5.QtGui import (
     QColor,
     QFont,
@@ -32,20 +33,29 @@ from tool.backends import ScreenAnalysis
 from tool.config import AppSettings, PROJECT_ROOT, get_cache_dir
 from tool.generate import generate_fgimage
 from tool.portraits import default_layers, layers_for
-from tool.runtime_logging import get_logger
 from tool.storage import HistoryStore, ScreenMemoryEntry, ScreenMemoryStore
 from tool.time_utils import build_time_context
-from tool.windowing import (
-    ensure_window_topmost,
-    get_system_idle_seconds,
-    native_topmost_available,
-)
 
 
-SCREEN_PIXEL_CHANGE_THRESHOLD = 0.008
+SCREEN_PIXEL_CHANGE_THRESHOLD = 0.012
+SCREEN_PET_MASK_MARGIN = 8
 PROACTIVE_COOLDOWN_SECONDS = 180
-TOPMOST_WATCHDOG_INTERVAL_MS = 2_000
-logger = get_logger("window")
+
+
+def screen_local_mask_rect(
+    screen_geometry: QRect,
+    window_geometry: QRect,
+    margin: int = SCREEN_PET_MASK_MARGIN,
+) -> QRect:
+    """Return the visible pet window bounds in screen-local coordinates."""
+    expanded = window_geometry.adjusted(-margin, -margin, margin, margin)
+    visible = expanded.intersected(screen_geometry)
+    if visible.isEmpty():
+        return QRect()
+    return visible.translated(
+        -screen_geometry.x(),
+        -screen_geometry.y(),
+    )
 
 
 def wrap_text(text: str, width: int = 10) -> str:
@@ -59,8 +69,29 @@ def wrap_text(text: str, width: int = 10) -> str:
     )
 
 
+class LastInputInfo(ctypes.Structure):
+    _fields_ = [
+        ("cbSize", ctypes.c_uint),
+        ("dwTime", ctypes.c_uint),
+    ]
+
+
 def get_idle_seconds() -> float:
-    return get_system_idle_seconds()
+    """Return global input idle time on Windows; return zero elsewhere."""
+
+    try:
+        user32 = ctypes.windll.user32
+        kernel32 = ctypes.windll.kernel32
+    except AttributeError:
+        return 0.0
+
+    info = LastInputInfo()
+    info.cbSize = ctypes.sizeof(LastInputInfo)
+    if not user32.GetLastInputInfo(ctypes.byref(info)):
+        return 0.0
+
+    idle_milliseconds = (kernel32.GetTickCount() - info.dwTime) & 0xFFFFFFFF
+    return idle_milliseconds / 1000.0
 
 
 class Murasame(QLabel):
@@ -106,10 +137,6 @@ class Murasame(QLabel):
         self._screen_resize_timer.timeout.connect(
             self._adapt_to_current_screen
         )
-        self._topmost_error_logged = False
-        self._topmost_timer = QTimer(self)
-        self._topmost_timer.setInterval(TOPMOST_WATCHDOG_INTERVAL_MS)
-        self._topmost_timer.timeout.connect(self._ensure_topmost)
 
         self.history_store = HistoryStore(limit=self.settings.history_limit)
         self.history = self.history_store.load()
@@ -237,36 +264,6 @@ class Murasame(QLabel):
         self.settings.vision.enabled = bool(enabled)
         self._apply_automatic_behavior_settings()
 
-    def showEvent(self, event) -> None:
-        super().showEvent(event)
-        if native_topmost_available():
-            self._topmost_timer.start()
-            QTimer.singleShot(0, self._ensure_topmost)
-
-    def hideEvent(self, event) -> None:
-        self._topmost_timer.stop()
-        super().hideEvent(event)
-
-    def changeEvent(self, event) -> None:
-        super().changeEvent(event)
-        if event.type() in {
-            QEvent.ActivationChange,
-            QEvent.WindowStateChange,
-        }:
-            QTimer.singleShot(0, self._ensure_topmost)
-
-    def _ensure_topmost(self) -> None:
-        if not native_topmost_available() or not self.isVisible():
-            return
-        try:
-            ensure_window_topmost(int(self.winId()))
-        except OSError as exc:
-            if not self._topmost_error_logged:
-                logger.warning("无法重新确认桌宠窗口置顶状态：%s", exc)
-                self._topmost_error_logged = True
-        else:
-            self._topmost_error_logged = False
-
     def is_screenshot_enabled(self) -> bool:
         return self.settings.vision.enabled
 
@@ -381,6 +378,7 @@ class Murasame(QLabel):
         if pixmap.isNull():
             self.notification.emit("屏幕分析", "屏幕截图失败")
             return
+        self._mask_pet_from_screenshot(pixmap, screen)
         if not pixmap.save(str(image_path), "PNG"):
             self.notification.emit("屏幕分析", "屏幕截图失败")
             return
@@ -413,6 +411,23 @@ class Murasame(QLabel):
         worker.finished.connect(lambda: self._finish_vision_worker(worker))
         worker.start()
 
+    def _mask_pet_from_screenshot(
+        self,
+        pixmap: QPixmap,
+        screen: QScreen,
+    ) -> None:
+        mask = screen_local_mask_rect(
+            screen.geometry(),
+            self.frameGeometry(),
+        )
+        if mask.isEmpty():
+            return
+        painter = QPainter(pixmap)
+        try:
+            painter.fillRect(mask, QColor(0, 0, 0))
+        finally:
+            painter.end()
+
     def _finish_vision_worker(self, worker: VisionWorker) -> None:
         if self._vision_worker is worker:
             self._vision_worker = None
@@ -439,9 +454,12 @@ class Murasame(QLabel):
     @staticmethod
     def _screen_event_key(analysis: ScreenAnalysis) -> str:
         parts = (
+            analysis.change_type,
             analysis.software,
             analysis.activity,
             analysis.topic,
+            ",".join(analysis.recognized_characters),
+            str(analysis.murasame_visible),
             analysis.change_summary,
         )
         return "|".join(" ".join(part.casefold().split()) for part in parts)
@@ -456,6 +474,7 @@ class Murasame(QLabel):
             return
         if (
             not analysis.significant_change
+            or analysis.change_type == "none"
             or not analysis.change_summary.strip()
         ):
             return
@@ -465,22 +484,38 @@ class Murasame(QLabel):
             return
         self.screen_memory_store.remember(
             ScreenMemoryEntry.now(
+                change_type=analysis.change_type,
                 software=analysis.software,
                 activity=analysis.activity,
                 topic=analysis.topic,
+                recognized_characters=analysis.recognized_characters,
+                murasame_visible=analysis.murasame_visible,
                 change_summary=analysis.change_summary,
             )
         )
         if event_key == self._last_spoken_screen_event:
             return
 
-        details = ["屏幕发生了明显变化。"]
+        details = [
+            "屏幕发生了明显变化。",
+            f"变化类型：{analysis.change_type}",
+        ]
         if analysis.software:
             details.append(f"软件：{analysis.software}")
         if analysis.activity:
             details.append(f"当前活动：{analysis.activity}")
         if analysis.topic:
             details.append(f"页面主题：{analysis.topic}")
+        if analysis.recognized_characters:
+            details.append(
+                "识别到的角色："
+                + "、".join(analysis.recognized_characters)
+            )
+        if analysis.murasame_visible:
+            details.append(
+                "画面中出现丛雨的角色形象；这是你自己的形象或作品画面，"
+                "不是另一个对话者。"
+            )
         if analysis.change_summary:
             details.append(f"变化摘要：{analysis.change_summary}")
         details.append(f"当前时间：{build_time_context()}")
@@ -1077,7 +1112,6 @@ class Murasame(QLabel):
         self.show_text("已经忘掉之前的对话和屏幕事件了。", typing=False)
 
     def shutdown(self) -> None:
-        self._topmost_timer.stop()
         self._screen_resize_timer.stop()
         self.screenshot_timer.stop()
         self.idle_timer.stop()

--- a/classes/murasame_class.py
+++ b/classes/murasame_class.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import ctypes
+import sys
 import textwrap
 import time
 import uuid
@@ -37,6 +37,7 @@ from tool.storage import HistoryStore, ScreenMemoryEntry, ScreenMemoryStore
 from tool.time_utils import build_time_context
 from tool.windowing import (
     ensure_window_topmost,
+    get_system_idle_seconds,
     native_topmost_available,
 )
 
@@ -58,29 +59,8 @@ def wrap_text(text: str, width: int = 10) -> str:
     )
 
 
-class LastInputInfo(ctypes.Structure):
-    _fields_ = [
-        ("cbSize", ctypes.c_uint),
-        ("dwTime", ctypes.c_uint),
-    ]
-
-
 def get_idle_seconds() -> float:
-    """Return global input idle time on Windows; return zero elsewhere."""
-
-    try:
-        user32 = ctypes.windll.user32
-        kernel32 = ctypes.windll.kernel32
-    except AttributeError:
-        return 0.0
-
-    info = LastInputInfo()
-    info.cbSize = ctypes.sizeof(LastInputInfo)
-    if not user32.GetLastInputInfo(ctypes.byref(info)):
-        return 0.0
-
-    idle_milliseconds = (kernel32.GetTickCount() - info.dwTime) & 0xFFFFFFFF
-    return idle_milliseconds / 1000.0
+    return get_system_idle_seconds()
 
 
 class Murasame(QLabel):
@@ -90,6 +70,7 @@ class Murasame(QLabel):
         super().__init__()
         self.settings = settings.model_copy(deep=True)
         self.pet_name = "丛雨"
+        self._native_overlay_dir = get_cache_dir() / "native_overlay"
 
         self.full_text = ""
         self.display_text = ""
@@ -164,6 +145,8 @@ class Murasame(QLabel):
             Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint | Qt.Tool
         )
         self.setAttribute(Qt.WA_TranslucentBackground, True)
+        if sys.platform == "darwin":
+            self.setAttribute(Qt.WA_MacAlwaysShowToolWindow, True)
         self.setFocusPolicy(Qt.StrongFocus)
         self.setAttribute(Qt.WA_InputMethodEnabled, True)
         self.setMouseTracking(True)
@@ -697,6 +680,7 @@ class Murasame(QLabel):
         )
         self.setPixmap(pixmap)
         self.resize(pixmap.size())
+        self._save_native_overlay_portrait(pixmap)
         if previous_geometry is not None and screen is not None:
             available = screen.availableGeometry()
             x = previous_geometry.center().x() - pixmap.width() // 2
@@ -807,6 +791,7 @@ class Murasame(QLabel):
         scaled = self._scale_portrait_pixmap(source, screen)
         self.setPixmap(scaled)
         self.resize(scaled.size())
+        self._save_native_overlay_portrait(scaled)
 
         available = screen.availableGeometry()
         x = old_geometry.center().x() - scaled.width() // 2
@@ -856,9 +841,11 @@ class Murasame(QLabel):
         self.typing_timer.stop()
         if typing:
             self.display_text = self.typing_prefix
+            self._save_native_overlay_text()
             self.typing_timer.start()
         else:
             self.display_text = self.typing_prefix + self.full_text
+            self._save_native_overlay_text()
             self.update()
 
     def _start_thinking_animation(self) -> None:
@@ -875,6 +862,7 @@ class Murasame(QLabel):
         self.full_text = "." * self._thinking_dot_count
         self.typing_prefix = f"【{self.pet_name}】\n"
         self.display_text = self.typing_prefix + self.full_text
+        self._save_native_overlay_text()
         self.update()
 
     def _typing_step(self) -> None:
@@ -885,6 +873,7 @@ class Murasame(QLabel):
         self.display_text = (
             self.typing_prefix + self.full_text[: self.typing_index]
         )
+        self._save_native_overlay_text()
         self.update()
 
     def paintEvent(self, event) -> None:
@@ -943,6 +932,7 @@ class Murasame(QLabel):
                     f"【{self.settings.character.user_name}】\n  「...」"
                 )
                 self.setFocus()
+                self._save_native_overlay_text()
                 self.update()
             else:
                 self.touch_head = False
@@ -1041,7 +1031,36 @@ class Murasame(QLabel):
         self.display_text = (
             f"【{self.settings.character.user_name}】\n  「{content}」"
         )
+        self._save_native_overlay_text()
         self.update()
+
+    @property
+    def native_overlay_directory(self) -> Path:
+        return self._native_overlay_dir
+
+    def _save_native_overlay_portrait(self, pixmap: QPixmap) -> None:
+        if sys.platform != "darwin":
+            return
+        try:
+            self._native_overlay_dir.mkdir(parents=True, exist_ok=True)
+            temporary = self._native_overlay_dir / "portrait.tmp.png"
+            target = self._native_overlay_dir / "portrait.png"
+            if pixmap.save(str(temporary), "PNG"):
+                temporary.replace(target)
+        except OSError:
+            pass
+
+    def _save_native_overlay_text(self) -> None:
+        if sys.platform != "darwin":
+            return
+        try:
+            self._native_overlay_dir.mkdir(parents=True, exist_ok=True)
+            temporary = self._native_overlay_dir / "text.tmp"
+            target = self._native_overlay_dir / "text.txt"
+            temporary.write_text(self.display_text or "", encoding="utf-8")
+            temporary.replace(target)
+        except OSError:
+            pass
 
     def clear_history(self) -> None:
         self._cancel_active_jobs()

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -1,4 +1,8 @@
-<p align="center">
+
+
+## macOS（Apple Silicon）
+
+macOS Apple Silicon 适配版请前往[Releases 页面](../../releases)下载；从源码运行时，请在项目目录执行 `start_macos.command`。<p align="center">
   <img src="../../icon.png" width="112" alt="AIpet 图标">
 </p>
 

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -41,7 +41,7 @@ AIpet 是一款支持 Windows 与 Apple Silicon macOS 的丛雨 AI 桌宠。它�
 
 项目基于
 [LemonQu-GIT/MurasamePet](https://github.com/LemonQu-GIT/MurasamePet)
-继续开发。演示、部署视频和项目动态见
+继续开发。win版的演示、部署视频和项目动态见
 [哔哩哔哩主页](https://space.bilibili.com/1067030066)。
 
 ## 主要功能

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -43,7 +43,7 @@ faster-whisper 语音输入组合在一起，保留原作者 V2 的界面和操�
 
 项目基于
 [LemonQu-GIT/MurasamePet](https://github.com/LemonQu-GIT/MurasamePet)
-继续开发。的演示、部署视频和项目动态见
+继续开发。macOS 版的演示、部署视频和项目动态见
 [哔哩哔哩主页](https://space.bilibili.com/1067030066)。
 
 ## 主要功能

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -41,7 +41,7 @@ AIpet 是一款支持 Windows 与 Apple Silicon macOS 的丛雨 AI 桌宠。它�
 
 项目基于
 [LemonQu-GIT/MurasamePet](https://github.com/LemonQu-GIT/MurasamePet)
-继续开发。win版的演示、部署视频和项目动态见
+继续开发。的演示、部署视频和项目动态见
 [哔哩哔哩主页](https://space.bilibili.com/1067030066)。
 
 ## 主要功能

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -2,15 +2,14 @@
   <img src="../../icon.png" width="112" alt="AIpet 图标">
 </p>
 
-<h1 align="center">AIpet · 丛雨桌宠</h1>
+<h1 align="center">AIpet · 丛雨桌宠 for macOS</h1>
 
 <p align="center">
-  <strong>使用提示词塑造人格，可自由切换本地与云端模型的 AI 桌面伴侣。</strong>
+  <strong>面向 Apple Silicon macOS 的丛雨桌宠适配版。</strong>
 </p>
 
 <p align="center">
   <img alt="Python 3.10+" src="https://img.shields.io/badge/Python-3.10%2B-3776AB?style=flat-square&logo=python&logoColor=white">
-  <img alt="Windows" src="https://img.shields.io/badge/Platform-Windows-0078D4?style=flat-square&logo=windows11&logoColor=white">
   <img alt="macOS" src="https://img.shields.io/badge/Platform-macOS-000000?style=flat-square&logo=apple&logoColor=white">
   <img alt="PyQt5" src="https://img.shields.io/badge/UI-PyQt5-41CD52?style=flat-square&logo=qt&logoColor=white">
   <img alt="Ollama" src="https://img.shields.io/badge/Local-Ollama-111111?style=flat-square&logo=ollama&logoColor=white">
@@ -28,6 +27,9 @@
 
 ---
 
+> 本 Fork 是 AIpet-Murasame 的 macOS 版本，保留原项目的界面和操作方式，
+> 并补充 Apple Silicon、全屏 Space、macOS 输入法和本地 TTS 等原生适配。
+
 如果你喜欢让丛雨陪在桌面上，就请给项目一颗
 [Star ⭐](https://github.com/kuxiaowo/AIpet-Murasame/stargazers)，或去
 [B站](https://space.bilibili.com/1067030066)
@@ -35,10 +37,10 @@
 
 ## 项目简介
 
-AIpet 是一款支持 Windows 与 Apple Silicon macOS 的丛雨 AI 桌宠。它将
-透明 PyQt5 角色窗口、本地或云端对话、可选的屏幕感知、GPT-SoVITS 语音
-输出和 faster-whisper 语音输入组合在一起。本版本保留原作者 V2 的界面和
-操作方式，仅补充 macOS 原生适配。
+本项目是 AIpet-Murasame 的 Apple Silicon macOS 适配版。它将透明 PyQt5
+角色窗口、本地或云端对话、可选的屏幕感知、GPT-SoVITS 语音输出和
+faster-whisper 语音输入组合在一起，保留原作者 V2 的界面和操作方式，
+并补充 macOS 原生适配。
 
 项目基于
 [LemonQu-GIT/MurasamePet](https://github.com/LemonQu-GIT/MurasamePet)
@@ -53,55 +55,13 @@ AIpet 是一款支持 Windows 与 Apple Silicon macOS 的丛雨 AI 桌宠。它�
 - 本地或 AutoDL 云端 GPT-SoVITS 语音合成
 - 基于 faster-whisper 的按键语音输入
 - 对话记忆、屏幕事件摘要、主动提醒和持久化勿扰模式
-- 透明多屏窗口、Windows 置顶守护、macOS 全屏 Space 与原生输入法兼容、
+- 透明多屏窗口、macOS 菜单栏集成、全屏 Space 与原生输入法兼容、
   中英双语设置和结构化诊断日志
 
 ## 快速开始
 
-项目支持 Windows 10/11 与 Apple Silicon macOS。
-
-### 直接运行 Windows EXE
-
-从项目 [Releases 页面](https://github.com/kuxiaowo/AIpet-Murasame/releases)
-选择一个版本：
-
-- **`AIpet.exe`（标准版，约 194 MiB）：**不附带 CUDA，适合使用 CPU
-  进行 Whisper 语音识别，或不需要本地语音识别 GPU 加速的用户。不确定
-  应该下载哪个版本时，建议选择这个版本。
-- **`AIpet-with-cuda.exe`（CUDA 版，约 1.06 GiB）：**附带 CUDA 12
-  cuBLAS、cuDNN 9 和 NVRTC，可通过兼容的 NVIDIA 显卡加速本地
-  faster-whisper 语音识别；仍需安装兼容的 NVIDIA 显卡驱动。如果在设置中
-  选择 CUDA，请使用这个版本。
-
-两个版本拥有相同的应用功能和设置界面。CUDA 版体积较大，仅仅是因为其中
-附带了 GPU 运行库。
-
-1. 下载所选的 EXE。如果该版本没有 EXE，请使用下方的源码方案。
-2. 把程序放到长期使用且可写的目录，例如 `C:\AIpet\`。
-3. 双击下载的 EXE。
-
-两个 EXE 均已包含应用程序和 faster-whisper 运行依赖，不要求安装
-Python、Conda 或 Git。聊天模型、Whisper 模型及 GPT-SoVITS 资源不会打进
-EXE；可选资源只会在设置界面确认后下载。
-
-### 从源码运行
-
-先安装 [Git](https://git-scm.com/) 和
-[Conda 或 Miniconda](https://docs.conda.io/)，然后执行：
-
-```powershell
-git clone https://github.com/kuxiaowo/AIpet-Murasame.git
-cd AIpet-Murasame
-conda env create -f environment.yml
-conda activate aipet
-python main.py
-```
-
-源码版如需语音输入，再安装附加依赖：
-
-```powershell
-python -m pip install -r requirements-voice.txt
-```
+本 Fork 面向 Apple Silicon macOS。Windows EXE 和构建说明属于原作者项目，
+这里不作为本版本的安装方式。
 
 ### 在 macOS 上运行
 
@@ -133,17 +93,17 @@ AIpet 至少需要本地 Ollama 或一种云端 API。
 
 使用 Ollama 时，启动服务并拉取对话模型；视觉模型可选：
 
-```powershell
+```zsh
 ollama pull qwen3:14b
 ollama pull qwen2.5vl:7b
 ```
 
 使用云端服务时，可以在设置中填写密钥，也可以使用环境变量：
 
-```powershell
-$env:DEEPSEEK_API_KEY = "your-key"
-$env:DASHSCOPE_API_KEY = "your-key"
-$env:OPENAI_API_KEY = "your-key"
+```zsh
+export DEEPSEEK_API_KEY="your-key"
+export DASHSCOPE_API_KEY="your-key"
+export OPENAI_API_KEY="your-key"
 ```
 
 macOS 终端中请使用对应的 `export NAME="value"` 写法。
@@ -158,7 +118,7 @@ macOS 终端中请使用对应的 `export NAME="value"` 写法。
 | 屏幕感知 | 启用“屏幕视觉”，选择 Ollama、阿里云百炼或 OpenAI 兼容视觉模型。截图仅作临时处理，不写入对话历史。 |
 | 本地 TTS | 启用“TTS → 本地计算机”，在设置中点击“安装 macOS GPT-SoVITS”；安装程序会把官方引擎和基础模型放在项目目录内，并将 Conda 环境放在 `~/.local/share/AIpet-Murasame/`。完成后点击“下载角色语音模型”，获取丛雨权重和参考音频。 |
 | AutoDL TTS | 启用“TTS → AutoDL 云端”，填写 SSH 登录信息、远程命令和参考音频目录。远程实例需已在 `9880` 端口提供 GPT-SoVITS 服务。 |
-| 语音输入 | Windows 上可启用语音输入，选择麦克风、计算设备和 faster-whisper 模型，长按 Caps Lock 两秒开始录音；macOS 上改为长按 Option+V 两秒。 |
+| 语音输入 | 启用语音输入，选择麦克风和 faster-whisper 模型，长按 Option+V 两秒开始录音。 |
 
 TTS 失败不会丢弃文字回复。临时截图、录音和合成语音会自动清理，也可以在
 设置中手动清除。
@@ -174,27 +134,13 @@ TTS 失败不会丢弃文字回复。临时截图、录音和合成语音会自�
 | 取消输入 | 按 Escape |
 | 摸头 | 在头部按住鼠标左键并横向移动 |
 | 移动桌宠 | 按住鼠标中键拖动 |
-| 语音对话 | Windows 上启用语音输入后长按 Caps Lock 两秒；macOS 上长按 Option+V 两秒 |
+| 语音对话 | 长按 Option+V 两秒 |
 | 设置、视觉、勿扰、记忆、退出 | 使用系统托盘菜单 |
 
 把桌宠拖到另一台显示器后，程序会自动更新显示器和立绘比例。
 macOS 原生全屏窗口保持相同的操作方式。
 
 ## 数据与隐私
-
-Windows 上的设置和持久化数据保存在：
-
-```text
-%APPDATA%\AIpet-Murasame\
-├── config.json
-├── history.json
-├── screen_memory.json
-├── personality.txt
-└── logs\
-```
-
-临时运行数据保存在 `%LOCALAPPDATA%\AIpet-Murasame\cache\`。下载模型默认
-保存在 `C:\AIpet\models\`；可以通过 `AIPET_MODEL_DIR` 修改模型目录。
 
 macOS 上的持久化数据及日志位于 `~/.config/AIpet-Murasame/`，运行缓存位于
 其 `cache/` 子目录，下载模型默认位于项目的 `models/` 目录。AutoDL 密码
@@ -206,45 +152,10 @@ Base64 媒体替换成元数据。
 
 ## 开发
 
-在 `aipet` Conda 环境中运行测试：
-
-```powershell
-$env:QT_QPA_PLATFORM = "offscreen"
-python -m unittest discover -s tests -v
-```
-
 macOS 上运行：
 
 ```zsh
 QT_QPA_PLATFORM=offscreen .venv/bin/python -m unittest discover -s tests -v
-```
-
-同时构建两个 Windows 单文件 EXE：
-
-```powershell
-.\packaging\build_exe.ps1
-```
-
-脚本会在需要时创建独立的 `aipet_build_whisper` Conda 环境，并输出：
-
-- `dist\AIpet.exe`：标准 CPU 版本。
-- `dist\AIpet-with-cuda.exe`：附带 CUDA 12 cuBLAS、cuDNN 9 和 NVRTC
-  运行库，可用于本地 Whisper GPU 推理的 CUDA 版本。
-
-构建环境未变化时可跳过依赖安装：
-
-```powershell
-.\packaging\build_exe.ps1 -SkipDependencyInstall
-```
-
-跳过依赖安装时，构建环境中必须已有 CUDA 12 cuBLAS、cuDNN 9 和 NVRTC
-运行库。如果它们不在构建环境的 `Library\bin` 中，可以分别指定目录：
-
-```powershell
-.\packaging\build_exe.ps1 -SkipDependencyInstall `
-  -CudaDllDirectory C:\path\to\cublas\bin `
-  -CudnnDllDirectory C:\path\to\cudnn\bin `
-  -CudaNvrtcDllDirectory C:\path\to\nvrtc\bin
 ```
 
 主要目录：
@@ -262,8 +173,7 @@ tests\      单元测试和 UI 冒烟测试
 
 - 独占全屏或受反作弊保护的画面仍可能覆盖桌宠。
 - macOS 辅助组件面向 Apple Silicon，并在首次启动时于本机编译。
-- Apple Silicon 上的 faster-whisper 使用 CPU；CUDA 模式适用于兼容的
-  Windows/NVIDIA 环境。
+- Apple Silicon 上的 faster-whisper 使用 CPU。
 - 本地对话、视觉与 TTS 的速度取决于模型和硬件。
 - 角色立绘与语音素材的使用条款可能不同于源代码许可证。
 
@@ -271,7 +181,7 @@ tests\      单元测试和 UI 冒烟测试
 
 - 原作桌宠项目：
   [LemonQu-GIT/MurasamePet](https://github.com/LemonQu-GIT/MurasamePet)
-- AIpet V2 原项目及 Windows 实现：
+- AIpet V2 原项目：
   [kuxiaowo/AIpet-Murasame](https://github.com/kuxiaowo/AIpet-Murasame)
 - 语音合成项目：
   [RVC-Boss/GPT-SoVITS](https://github.com/RVC-Boss/GPT-SoVITS)

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -18,7 +18,6 @@
 
 <p align="center">
   <a href="https://github.com/kuxiaowo/AIpet-Murasame/stargazers"><img alt="GitHub Stars" src="https://img.shields.io/github/stars/kuxiaowo/AIpet-Murasame?style=flat-square&logo=github"></a>
-  <a href="https://space.bilibili.com/1067030066"><img alt="哔哩哔哩" src="https://img.shields.io/badge/Bilibili-视频教程-00A1D6?style=flat-square&logo=bilibili&logoColor=white"></a>
 </p>
 
 <p align="center">
@@ -43,8 +42,7 @@ faster-whisper 语音输入组合在一起，保留原作者 V2 的界面和操�
 
 项目基于
 [LemonQu-GIT/MurasamePet](https://github.com/LemonQu-GIT/MurasamePet)
-继续开发。macOS 版的演示、部署视频和项目动态见
-[哔哩哔哩主页](https://space.bilibili.com/1067030066)。
+继续开发。
 
 ## 主要功能
 

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -11,6 +11,7 @@
 <p align="center">
   <img alt="Python 3.10+" src="https://img.shields.io/badge/Python-3.10%2B-3776AB?style=flat-square&logo=python&logoColor=white">
   <img alt="Windows" src="https://img.shields.io/badge/Platform-Windows-0078D4?style=flat-square&logo=windows11&logoColor=white">
+  <img alt="macOS" src="https://img.shields.io/badge/Platform-macOS-000000?style=flat-square&logo=apple&logoColor=white">
   <img alt="PyQt5" src="https://img.shields.io/badge/UI-PyQt5-41CD52?style=flat-square&logo=qt&logoColor=white">
   <img alt="Ollama" src="https://img.shields.io/badge/Local-Ollama-111111?style=flat-square&logo=ollama&logoColor=white">
   <a href="../../LICENSE"><img alt="许可证" src="https://img.shields.io/github/license/kuxiaowo/AIpet-Murasame?style=flat-square&color=8A2BE2"></a>
@@ -34,9 +35,10 @@
 
 ## 项目简介
 
-AIpet 是一款面向 Windows 的丛雨 AI 桌宠。它将透明 PyQt5 角色窗口、本地或
-云端对话、可选的屏幕感知、GPT-SoVITS 语音输出和 faster-whisper 语音输入
-组合在一起。
+AIpet 是一款支持 Windows 与 Apple Silicon macOS 的丛雨 AI 桌宠。它将
+透明 PyQt5 角色窗口、本地或云端对话、可选的屏幕感知、GPT-SoVITS 语音
+输出和 faster-whisper 语音输入组合在一起。本版本保留原作者 V2 的界面和
+操作方式，仅补充 macOS 原生适配。
 
 项目基于
 [LemonQu-GIT/MurasamePet](https://github.com/LemonQu-GIT/MurasamePet)
@@ -51,11 +53,12 @@ AIpet 是一款面向 Windows 的丛雨 AI 桌宠。它将透明 PyQt5 角色窗
 - 本地或 AutoDL 云端 GPT-SoVITS 语音合成
 - 基于 faster-whisper 的按键语音输入
 - 对话记忆、屏幕事件摘要、主动提醒和持久化勿扰模式
-- 透明多屏窗口、Windows 置顶守护、中英双语设置和结构化诊断日志
+- 透明多屏窗口、Windows 置顶守护、macOS 全屏 Space 与原生输入法兼容、
+  中英双语设置和结构化诊断日志
 
 ## 快速开始
 
-项目主要支持 Windows 10 和 Windows 11。
+项目支持 Windows 10/11 与 Apple Silicon macOS。
 
 ### 直接运行 Windows EXE
 
@@ -100,6 +103,30 @@ python main.py
 python -m pip install -r requirements-voice.txt
 ```
 
+### 在 macOS 上运行
+
+需要：
+
+- Apple Silicon Mac
+- Python 3.10 或更高版本
+- Xcode Command Line Tools（运行 `xcode-select --install` 安装）
+
+双击 **`start_macos.command`**，或在终端执行：
+
+```zsh
+./start_macos.command
+```
+
+首次启动会创建 `.venv`、安装程序及语音输入依赖，并编译一个很小的原生
+全屏辅助组件。macOS 可能会请求以下权限：
+
+- “屏幕录制”：供屏幕视觉使用
+- “麦克风”：供语音输入使用
+- “辅助功能 / 输入监控”：供 macOS 上长按 Option+V 触发语音输入
+
+只有当其他应用进入全屏 Space 时，程序才会切换到原生辅助窗口。它沿用原来
+的桌宠操作，并支持在全屏中使用 macOS 拼音组合输入和候选词。
+
 ### 配置对话后端
 
 AIpet 至少需要本地 Ollama 或一种云端 API。
@@ -119,6 +146,8 @@ $env:DASHSCOPE_API_KEY = "your-key"
 $env:OPENAI_API_KEY = "your-key"
 ```
 
+macOS 终端中请使用对应的 `export NAME="value"` 写法。
+
 首次启动后，选择后端与模型，填写用户名称，检查人格提示词并保存。视觉、TTS
 和语音输入属于可选功能，相关依赖尚未准备好时请先保持关闭。
 
@@ -127,12 +156,15 @@ $env:OPENAI_API_KEY = "your-key"
 | 功能 | 配置方法 |
 |---|---|
 | 屏幕感知 | 启用“屏幕视觉”，选择 Ollama、阿里云百炼或 OpenAI 兼容视觉模型。截图仅作临时处理，不写入对话历史。 |
-| 本地 TTS | 启用“TTS → 本地计算机”，选择 GPT-SoVITS 引擎和丛雨语音模型目录。缺少的托管资源可在确认后下载。 |
+| 本地 TTS | 启用“TTS → 本地计算机”，在设置中点击“安装 macOS GPT-SoVITS”；安装程序会把官方引擎和基础模型放在项目目录内，并将 Conda 环境放在 `~/.local/share/AIpet-Murasame/`。完成后点击“下载角色语音模型”，获取丛雨权重和参考音频。 |
 | AutoDL TTS | 启用“TTS → AutoDL 云端”，填写 SSH 登录信息、远程命令和参考音频目录。远程实例需已在 `9880` 端口提供 GPT-SoVITS 服务。 |
-| 语音输入 | 启用语音输入，选择麦克风、计算设备和 faster-whisper 模型。长按 Caps Lock 两秒开始录音，松开后识别并发送。 |
+| 语音输入 | Windows 上可启用语音输入，选择麦克风、计算设备和 faster-whisper 模型，长按 Caps Lock 两秒开始录音；macOS 上改为长按 Option+V 两秒。 |
 
 TTS 失败不会丢弃文字回复。临时截图、录音和合成语音会自动清理，也可以在
 设置中手动清除。
+
+如果 macOS 的 GPT-SoVITS Python 环境不在引擎目录内，可将
+`AIPET_GPT_SOVITS_PYTHON` 指向该环境的 Python 可执行文件。
 
 ## 桌宠操作
 
@@ -142,10 +174,11 @@ TTS 失败不会丢弃文字回复。临时截图、录音和合成语音会自�
 | 取消输入 | 按 Escape |
 | 摸头 | 在头部按住鼠标左键并横向移动 |
 | 移动桌宠 | 按住鼠标中键拖动 |
-| 语音对话 | 启用语音输入后长按 Caps Lock 两秒 |
+| 语音对话 | Windows 上启用语音输入后长按 Caps Lock 两秒；macOS 上长按 Option+V 两秒 |
 | 设置、视觉、勿扰、记忆、退出 | 使用系统托盘菜单 |
 
 把桌宠拖到另一台显示器后，程序会自动更新显示器和立绘比例。
+macOS 原生全屏窗口保持相同的操作方式。
 
 ## 数据与隐私
 
@@ -163,6 +196,10 @@ Windows 上的设置和持久化数据保存在：
 临时运行数据保存在 `%LOCALAPPDATA%\AIpet-Murasame\cache\`。下载模型默认
 保存在 `C:\AIpet\models\`；可以通过 `AIPET_MODEL_DIR` 修改模型目录。
 
+macOS 上的持久化数据及日志位于 `~/.config/AIpet-Murasame/`，运行缓存位于
+其 `cache/` 子目录，下载模型默认位于项目的 `models/` 目录。AutoDL 密码
+保存在 macOS 钥匙串中。
+
 在设置中填写的 API Key 会写入 `config.json`。如果不希望密钥进入配置文件，
 请把密钥字段留空并使用环境变量。日志会对已识别的密钥字段脱敏，并把大型
 Base64 媒体替换成元数据。
@@ -174,6 +211,12 @@ Base64 媒体替换成元数据。
 ```powershell
 $env:QT_QPA_PLATFORM = "offscreen"
 python -m unittest discover -s tests -v
+```
+
+macOS 上运行：
+
+```zsh
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m unittest discover -s tests -v
 ```
 
 同时构建两个 Windows 单文件 EXE：
@@ -210,14 +253,17 @@ python -m unittest discover -s tests -v
 classes\    桌宠交互、后台任务和下载
 tool\       模型后端、配置、存储、语音和诊断
 ui\         中英双语设置窗口
+native_overlay/  macOS 原生全屏及输入桥接
 packaging\  可重复执行的 PyInstaller 构建
 tests\      单元测试和 UI 冒烟测试
 ```
 
 ## 已知限制
 
-- 桌面行为目前主要针对 Windows 设计和测试。
 - 独占全屏或受反作弊保护的画面仍可能覆盖桌宠。
+- macOS 辅助组件面向 Apple Silicon，并在首次启动时于本机编译。
+- Apple Silicon 上的 faster-whisper 使用 CPU；CUDA 模式适用于兼容的
+  Windows/NVIDIA 环境。
 - 本地对话、视觉与 TTS 的速度取决于模型和硬件。
 - 角色立绘与语音素材的使用条款可能不同于源代码许可证。
 
@@ -225,6 +271,8 @@ tests\      单元测试和 UI 冒烟测试
 
 - 原作桌宠项目：
   [LemonQu-GIT/MurasamePet](https://github.com/LemonQu-GIT/MurasamePet)
+- AIpet V2 原项目及 Windows 实现：
+  [kuxiaowo/AIpet-Murasame](https://github.com/kuxiaowo/AIpet-Murasame)
 - 语音合成项目：
   [RVC-Boss/GPT-SoVITS](https://github.com/RVC-Boss/GPT-SoVITS)
 

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -29,8 +29,7 @@
 ---
 
 如果你喜欢让丛雨陪在桌面上，就请给项目一颗
-[Star ⭐](https://github.com/kuxiaowo/AIpet-Murasame/stargazers)，或去
-[B站](https://space.bilibili.com/1067030066)
+[Star ⭐](https://github.com/kuxiaowo/AIpet-Murasame/stargazers)
 点个关注吧～丛雨会很开心，维护者也会更有动力继续更新的！
 
 ## 项目简介

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -1,16 +1,22 @@
 
 
+
+
 ## macOS（Apple Silicon）
+
 
 macOS Apple Silicon 适配版请前往[Releases 页面](../../releases)下载；从源码运行时，请在项目目录执行 `start_macos.command`。<p align="center">
   <img src="../../icon.png" width="112" alt="AIpet 图标">
 </p>
 
+
 <h1 align="center">AIpet · 丛雨桌宠</h1>
+
 
 <p align="center">
   <strong>使用提示词模拟人格、可自由切换本地与云端模型的 AI 桌面伴侣。</strong>
 </p>
+
 
 <p align="center">
   <img alt="Python 3.10+" src="https://img.shields.io/badge/Python-3.10%2B-3776AB?style=flat-square&logo=python&logoColor=white">
@@ -21,17 +27,23 @@ macOS Apple Silicon 适配版请前往[Releases 页面](../../releases)下载；
   <a href="../../LICENSE"><img alt="许可证" src="https://img.shields.io/github/license/kuxiaowo/AIpet-Murasame?style=flat-square&color=8A2BE2"></a>
 </p>
 
+
 <p align="center">
   <a href="../../README.md">English</a> | <strong>简体中文</strong>
 </p>
 
+
 ---
+
 
 ## 项目简介
 
+
 AIpet 是一个面向 Windows 的丛雨桌宠。人格完全由提示词模拟，项目不再内置聊天 Transformer、LoRA、PyTorch 推理服务或模型下载脚本。
 
+
 对话和视觉后端现在分别配置：
+
 
 | 用途 | 服务商 | 默认模型 |
 |---|---|---|
@@ -43,154 +55,9 @@ AIpet 是一个面向 Windows 的丛雨桌宠。人格完全由提示词模拟�
 | 视觉 | 阿里云百炼 | `qwen3-vl-plus` |
 | 视觉 | OpenAI | `gpt-5.6-luna` |
 
+
 模型名都可以在设置窗口中修改。语言模型使用云端 API 时，视觉仍可独立选择本地 Ollama。
 
-## 主要改进
+## macOS（适用于 Mac M 系列芯片）
 
-- Ollama / API 双模式，模型后端相互独立。
-- 内置 DeepSeek、阿里云和 OpenAI 接口。
-- 对话模型和视觉模型可以分别选择。
-- 首次启动显示中英双语设置，语言可即时切换。
-- 打开设置时会读取当前启用功能的模型列表；屏幕视觉关闭时，其配置整体禁用，也不会请求视觉后端。修改地址、服务商或密钥后可手动刷新，并始终允许直接输入模型 ID。
-- 在界面中直接创建、导入或修改人格提示词。
-- 模型只返回经过验证的中文、日语、情绪、`a`/`b` 立绘姿态和四种服装枚举，不会直接生成图层编号。
-- 模型可根据语境在睡衣、粉白便衣、校服和紫色和服之间换装；服装、姿态与情绪仍由程序映射为固定图层，更换模型也不会随机“拆脸”。
-- 中键拖到另一块显示器后，立绘会按新屏幕的可用高度自动缩放。
-- 可在“显示”中打开实时诊断命令行，查看带关联 ID 的请求/响应 JSON、后台事件、警告和异常信息；日志按天保存在项目的 `logs/YYYY-MM-DD.log`。API 密钥会脱敏，大型 Base64 媒体只记录长度与 SHA-256 摘要。
-- 截图只在 Qt 主线程产生，丛雨桌宠区域会在分析前遮罩，网络分析放到后台；视觉模型还会尝试识别画面中的动漫或游戏角色，包括丛雨自己。
-- 只有显著的屏幕变化会保存为有限、去重的结构化事件摘要，供后续对话参考；原始截图不会写入对话历史。
-- 配置、API Key 和历史记录移出仓库目录。
-- GPT-SoVITS 失败时仍然显示文本，不会吞掉整次回答。
-
-## 快速开始
-
-```bash
-git clone https://github.com/kuxiaowo/AIpet-Murasame.git
-cd AIpet-Murasame
-conda env create -f environment.yml
-conda activate aipet
-python main.py
-```
-
-也可以手动创建环境：
-
-```bash
-conda create -n aipet python=3.10 -y
-conda activate aipet
-python -m pip install -r requirements.txt
-python main.py
-```
-
-首次运行会打开 **AIpet 初始设置**。这里可以选择 Ollama / API、填写服务地址或 Key、选择模型、编辑人格并设置屏幕感知和语音。
-
-如果使用 Ollama，可以先准备示例模型：
-
-```bash
-ollama pull qwen3:14b
-ollama pull qwen2.5vl:7b
-```
-
-如果使用云端 API，也可以通过环境变量提供 Key：
-
-```powershell
-$env:DEEPSEEK_API_KEY = "your-key"
-$env:DASHSCOPE_API_KEY = "your-key"
-$env:OPENAI_API_KEY = "your-key"
-```
-
-## macOS（Apple Silicon）适配
-
-此目录的 macOS 版本保留原项目的设置窗口、托盘菜单和桌宠交互。使用
-`start_macos.command` 启动；首次启动会在项目目录创建 `.venv` 并安装
-依赖。系统进入其他应用的全屏 Space 时，会自动切换到原生兼容窗口，以
-保持桌宠显示和中文输入。
-
-macOS 不使用项目提供的 Windows GPT-SoVITS 整合包。需要语音时，请先按
-GPT-SoVITS 官方说明准备本地引擎，再在设置页面选择引擎和模型目录。
-
-## 可视化设置
-
-托盘菜单中的 **Settings… / 设置…** 可以随时打开设置。
-
-启用语音输入后，可以分别选择 faster-whisper 模型或仓库 ID、模型下载目录和实际录音输入设备；选择“系统默认”时跟随 Windows 默认输入设备。Windows 上的新配置默认使用 `C:\AIpet\models` 下的独立 Whisper、GPT-SoVITS 和丛雨语音模型目录；已有的自定义路径不会被覆盖。下载和加载都严格使用填写的目录，下载进度、大小和当前文件直接显示在语音设置卡片中，关闭设置后下载仍会继续。
-
-- **语言模型**：界面语言、后端模式、服务商、URL、对话模型、DeepSeek 思考模式、Ollama 上下文长度、超时和连接测试。
-- **拓展功能 / 屏幕视觉**：独立选择本地 Ollama、阿里云或 OpenAI 视觉后端及模型。
-- **Character**：用户名、默认立绘组、默认服装和人格提示词编辑器。
-- **自动行为**：设置空闲提醒、历史长度和可持久化的勿扰模式，也可以在确认后立即清除对话及屏幕事件记忆。
-- **显示**：选择显示器、立绘比例和实时日志窗口。
-
-程序会自动添加结构化输出规则，所以人格提示词只需要描述身份、说话风格、关系和边界。
-
-打开设置时会按已启用的功能加载模型列表：Ollama 调用 `GET /api/tags`，云端服务调用 OpenAI 兼容的 `GET /models`。屏幕视觉未启用时不会加载视觉模型列表。修改地址、服务商或 API Key 后，可以点击对应按钮重新测试和刷新。所有模型下拉框都可以直接编辑，因此模型列表接口失败、漏掉自定义模型或服务商未返回完整列表时，仍可手动填写。
-
-DeepSeek 已更新为 V4 接口模型名：`deepseek-v4-flash` 和 `deepseek-v4-pro`。旧配置中的 `deepseek-chat`、`deepseek-reasoner` 会自动迁移，并可以在界面中切换思考模式。
-
-## 数据与隐私
-
-Windows 下的用户数据位于：
-
-```text
-%APPDATA%\AIpet-Murasame\
-├── config.json
-├── history.json
-├── screen_memory.json
-└── personality.txt
-```
-
-临时语音和截图仍位于 `%LOCALAPPDATA%\AIpet-Murasame\cache`；Whisper 和 TTS 的新下载位置由用户在设置页分别指定。屏幕感知默认关闭；启用后，截图只会发送给当前配置的视觉模型。程序最多保存最近 12 条显著屏幕事件摘要，并在对话中按字符预算注入最近最多 8 条；连续相同事件会去重，原始截图不会持久化。
-
-通过设置窗口填写的 Key 会保存在用户配置中。如果希望进一步分离凭据，可以把 Key 字段留空并使用 `DEEPSEEK_API_KEY`、`DASHSCOPE_API_KEY` 或 `OPENAI_API_KEY` 环境变量。
-
-## GPT-SoVITS 与语音输入
-
-默认 TTS 地址为：
-
-```text
-http://127.0.0.1:9880/tts
-```
-
-六组参考音频统一放在角色语音模型目录内的 `reference_voices` 子目录中，因此只需填写角色语音模型目录。
-
-本地地址启用 TTS 后，AIpet 会依次检查 GPT-SoVITS 引擎目录、丛雨 GPT/SoVITS 权重、六组参考音频和服务状态。两个现有路径框同时也是实际下载目标：引擎解压到 GPT-SoVITS 目录，角色权重和参考音频下载到角色语音模型目录；所需路径为空时会提示用户先选择，不再静默改用项目默认目录。未检测到 GPT-SoVITS 时，程序会读取 NVIDIA 显卡名称：GeForce RTX 50 系列下载专用整合包，其他显卡或无法识别时下载通用整合包。设置卡片会分别显示准备、校验、下载、解压、安装和清理阶段；解压优先使用开启多线程的原生 7-Zip，找不到时使用 Windows bsdtar，安装时通过同盘原子移动避免再次复制整个目录。所有自动下载均不会打开网页。角色权重来自 `LemonQu/Murasame_SoVITS`，参考音频来自 `kuxiaowo/Murasame-tts-reference-voice`。
-
-首次发起本地 TTS 请求时，如果服务尚未运行，AIpet 会使用引擎自带的 Python 启动 `api_v2.py`，等待 OpenAPI 接口就绪，加载角色权重，再继续合成。设置页也可以手动启动或停止服务，并逐步显示定位环境、启动进程、等待接口和加载权重等状态。并发请求不会重复启动服务；退出程序时只关闭由本次 AIpet 进程启动的服务。远程 TTS 只检查接口状态，不会在本机启动、停止或修改远程服务。
-
-Caps Lock 语音输入是可选功能，需要额外安装：
-
-```bash
-python -m pip install -r requirements-voice.txt
-```
-
-## 操作方式
-
-| 操作 | 方式 |
-|---|---|
-| 输入消息 | 左键点击角色下半部分，输入后按 Enter |
-| 取消输入 | 按 Escape |
-| 摸头 | 在头部按住左键并横向移动 |
-| 移动桌宠 | 按住鼠标中键拖动 |
-| 语音输入 | 启用可选语音功能后长按 Caps Lock 两秒 |
-| 设置、视觉、勿扰、记忆、退出 | 使用系统托盘菜单 |
-
-## 测试
-
-在 Conda 环境中运行：
-
-```bash
-$env:QT_QPA_PLATFORM = "offscreen"
-python -m unittest discover -s tests -v
-```
-
-## 已知限制
-
-- 桌面行为主要面向 Windows 开发和测试。
-- 对话和视觉凭据分别配置；如果两者使用同一个云服务，可以在两个面板填写同一个 Key，或使用对应环境变量。
-- HTTP 请求采用协作式取消：旧请求可能在后台结束，但结果会被丢弃，不会覆盖新对话。
-- 角色立绘和语音素材的授权范围可能不同于源代码许可证。
-
-## 许可证与素材声明
-
-源代码使用 [GNU Affero General Public License v3.0](../../LICENSE)。
-
-这是用于学习和技术交流的非官方同人项目。丛雨及随附的第三方立绘、语音等素材权利归包括 YUZUSOFT 在内的各自权利人所有，不因源代码使用 AGPL 而被重新许可。未经许可请勿商用相关素材。
+适用于 Mac M 系列芯片的 macOS 适配版请前往[Releases 页面](../../releases)下载；从源码运行时，请在项目目录执行 `start_macos.command`。

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -2,22 +2,19 @@
   <img src="../../icon.png" width="112" alt="AIpet 图标">
 </p>
 
-<h1 align="center">AIpet · 丛雨桌宠 for macOS</h1>
+<h1 align="center">AIpet · 丛雨桌宠</h1>
 
 <p align="center">
-  <strong>面向 Apple Silicon macOS 的丛雨桌宠适配版。</strong>
+  <strong>使用提示词模拟人格、可自由切换本地与云端模型的 AI 桌面伴侣。</strong>
 </p>
 
 <p align="center">
   <img alt="Python 3.10+" src="https://img.shields.io/badge/Python-3.10%2B-3776AB?style=flat-square&logo=python&logoColor=white">
-  <img alt="macOS" src="https://img.shields.io/badge/Platform-macOS-000000?style=flat-square&logo=apple&logoColor=white">
+  <img alt="Windows" src="https://img.shields.io/badge/Platform-Windows-0078D4?style=flat-square&logo=windows11&logoColor=white">
   <img alt="PyQt5" src="https://img.shields.io/badge/UI-PyQt5-41CD52?style=flat-square&logo=qt&logoColor=white">
   <img alt="Ollama" src="https://img.shields.io/badge/Local-Ollama-111111?style=flat-square&logo=ollama&logoColor=white">
+  <img alt="云端 API" src="https://img.shields.io/badge/API-DeepSeek%20%7C%20Alibaba%20%7C%20OpenAI-6246EA?style=flat-square">
   <a href="../../LICENSE"><img alt="许可证" src="https://img.shields.io/github/license/kuxiaowo/AIpet-Murasame?style=flat-square&color=8A2BE2"></a>
-</p>
-
-<p align="center">
-  <a href="https://github.com/kuxiaowo/AIpet-Murasame/stargazers"><img alt="GitHub Stars" src="https://img.shields.io/github/stars/kuxiaowo/AIpet-Murasame?style=flat-square&logo=github"></a>
 </p>
 
 <p align="center">
@@ -26,167 +23,170 @@
 
 ---
 
-> 本 Fork 是 AIpet-Murasame 的 macOS 版本，保留原项目的界面和操作方式，
-> 并补充 Apple Silicon、全屏 Space、macOS 输入法和本地 TTS 等原生适配。
-
-如果你喜欢让丛雨陪在桌面上，就请给项目一颗
-[Star ⭐](https://github.com/kuxiaowo/AIpet-Murasame/stargazers)
-点个关注吧～丛雨会很开心，维护者也会更有动力继续更新的！
-
 ## 项目简介
 
-本项目是 AIpet-Murasame 的 Apple Silicon macOS 适配版。它将透明 PyQt5
-角色窗口、本地或云端对话、可选的屏幕感知、GPT-SoVITS 语音输出和
-faster-whisper 语音输入组合在一起，保留原作者 V2 的界面和操作方式，
-并补充 macOS 原生适配。
+AIpet 是一个面向 Windows 的丛雨桌宠。人格完全由提示词模拟，项目不再内置聊天 Transformer、LoRA、PyTorch 推理服务或模型下载脚本。
 
-项目基于
-[LemonQu-GIT/MurasamePet](https://github.com/LemonQu-GIT/MurasamePet)
-继续开发。
+对话和视觉后端现在分别配置：
 
-## 主要功能
+| 用途 | 服务商 | 默认模型 |
+|---|---|---|
+| 对话 | Ollama | `qwen3:14b` |
+| 对话 | DeepSeek | `deepseek-v4-flash` |
+| 对话 | 阿里云百炼 | `qwen-plus` |
+| 对话 | OpenAI | `gpt-5.6-luna` |
+| 视觉 | Ollama（本地） | `qwen2.5vl:7b` |
+| 视觉 | 阿里云百炼 | `qwen3-vl-plus` |
+| 视觉 | OpenAI | `gpt-5.6-luna` |
 
-- 支持 Ollama 本地对话，以及 DeepSeek、阿里云百炼和 OpenAI 兼容 API
-- 对话与视觉后端可独立配置，屏幕感知默认关闭
-- 提示词人格、两套立绘姿态、六种情绪和四套服装
-- 本地或 AutoDL 云端 GPT-SoVITS 语音合成
-- 基于 faster-whisper 的按键语音输入
-- 对话记忆、屏幕事件摘要、主动提醒和持久化勿扰模式
-- 透明多屏窗口、macOS 菜单栏集成、全屏 Space 与原生输入法兼容、
-  中英双语设置和结构化诊断日志
+模型名都可以在设置窗口中修改。语言模型使用云端 API 时，视觉仍可独立选择本地 Ollama。
+
+## 主要改进
+
+- Ollama / API 双模式，模型后端相互独立。
+- 内置 DeepSeek、阿里云和 OpenAI 接口。
+- 对话模型和视觉模型可以分别选择。
+- 首次启动显示中英双语设置，语言可即时切换。
+- 打开设置时会读取当前启用功能的模型列表；屏幕视觉关闭时，其配置整体禁用，也不会请求视觉后端。修改地址、服务商或密钥后可手动刷新，并始终允许直接输入模型 ID。
+- 在界面中直接创建、导入或修改人格提示词。
+- 模型只返回经过验证的中文、日语、情绪、`a`/`b` 立绘姿态和四种服装枚举，不会直接生成图层编号。
+- 模型可根据语境在睡衣、粉白便衣、校服和紫色和服之间换装；服装、姿态与情绪仍由程序映射为固定图层，更换模型也不会随机“拆脸”。
+- 中键拖到另一块显示器后，立绘会按新屏幕的可用高度自动缩放。
+- 可在“显示”中打开实时诊断命令行，查看带关联 ID 的请求/响应 JSON、后台事件、警告和异常信息；日志按天保存在项目的 `logs/YYYY-MM-DD.log`。API 密钥会脱敏，大型 Base64 媒体只记录长度与 SHA-256 摘要。
+- 截图只在 Qt 主线程产生，丛雨桌宠区域会在分析前遮罩，网络分析放到后台；视觉模型还会尝试识别画面中的动漫或游戏角色，包括丛雨自己。
+- 只有显著的屏幕变化会保存为有限、去重的结构化事件摘要，供后续对话参考；原始截图不会写入对话历史。
+- 配置、API Key 和历史记录移出仓库目录。
+- GPT-SoVITS 失败时仍然显示文本，不会吞掉整次回答。
 
 ## 快速开始
 
-本 Fork 面向 Apple Silicon macOS。Windows EXE 和构建说明属于原作者项目，
-这里不作为本版本的安装方式。
-
-### 在 macOS 上运行
-
-需要：
-
-- Apple Silicon Mac
-- Python 3.10 或更高版本
-- Xcode Command Line Tools（运行 `xcode-select --install` 安装）
-
-双击 **`start_macos.command`**，或在终端执行：
-
-```zsh
-./start_macos.command
+```bash
+git clone https://github.com/kuxiaowo/AIpet-Murasame.git
+cd AIpet-Murasame
+conda env create -f environment.yml
+conda activate aipet
+python main.py
 ```
 
-首次启动会创建 `.venv`、安装程序及语音输入依赖，并编译一个很小的原生
-全屏辅助组件。macOS 可能会请求以下权限：
+也可以手动创建环境：
 
-- “屏幕录制”：供屏幕视觉使用
-- “麦克风”：供语音输入使用
-- “辅助功能 / 输入监控”：供 macOS 上长按 Option+V 触发语音输入
+```bash
+conda create -n aipet python=3.10 -y
+conda activate aipet
+python -m pip install -r requirements.txt
+python main.py
+```
 
-只有当其他应用进入全屏 Space 时，程序才会切换到原生辅助窗口。它沿用原来
-的桌宠操作，并支持在全屏中使用 macOS 拼音组合输入和候选词。
+首次运行会打开 **AIpet 初始设置**。这里可以选择 Ollama / API、填写服务地址或 Key、选择模型、编辑人格并设置屏幕感知和语音。
 
-### 配置对话后端
+如果使用 Ollama，可以先准备示例模型：
 
-AIpet 至少需要本地 Ollama 或一种云端 API。
-
-使用 Ollama 时，启动服务并拉取对话模型；视觉模型可选：
-
-```zsh
+```bash
 ollama pull qwen3:14b
 ollama pull qwen2.5vl:7b
 ```
 
-使用云端服务时，可以在设置中填写密钥，也可以使用环境变量：
+如果使用云端 API，也可以通过环境变量提供 Key：
 
-```zsh
-export DEEPSEEK_API_KEY="your-key"
-export DASHSCOPE_API_KEY="your-key"
-export OPENAI_API_KEY="your-key"
+```powershell
+$env:DEEPSEEK_API_KEY = "your-key"
+$env:DASHSCOPE_API_KEY = "your-key"
+$env:OPENAI_API_KEY = "your-key"
 ```
 
-macOS 终端中请使用对应的 `export NAME="value"` 写法。
+## macOS（Apple Silicon）适配
 
-首次启动后，选择后端与模型，填写用户名称，检查人格提示词并保存。视觉、TTS
-和语音输入属于可选功能，相关依赖尚未准备好时请先保持关闭。
+此目录的 macOS 版本保留原项目的设置窗口、托盘菜单和桌宠交互。使用
+`start_macos.command` 启动；首次启动会在项目目录创建 `.venv` 并安装
+依赖。系统进入其他应用的全屏 Space 时，会自动切换到原生兼容窗口，以
+保持桌宠显示和中文输入。
 
-## 可选功能
+macOS 不使用项目提供的 Windows GPT-SoVITS 整合包。需要语音时，请先按
+GPT-SoVITS 官方说明准备本地引擎，再在设置页面选择引擎和模型目录。
 
-| 功能 | 配置方法 |
-|---|---|
-| 屏幕感知 | 启用“屏幕视觉”，选择 Ollama、阿里云百炼或 OpenAI 兼容视觉模型。截图仅作临时处理，不写入对话历史。 |
-| 本地 TTS | 启用“TTS → 本地计算机”，在设置中点击“安装 macOS GPT-SoVITS”；安装程序会把官方引擎和基础模型放在项目目录内，并将 Conda 环境放在 `~/.local/share/AIpet-Murasame/`。完成后点击“下载角色语音模型”，获取丛雨权重和参考音频。 |
-| AutoDL TTS | 启用“TTS → AutoDL 云端”，填写 SSH 登录信息、远程命令和参考音频目录。远程实例需已在 `9880` 端口提供 GPT-SoVITS 服务。 |
-| 语音输入 | 启用语音输入，选择麦克风和 faster-whisper 模型，长按 Option+V 两秒开始录音。 |
+## 可视化设置
 
-TTS 失败不会丢弃文字回复。临时截图、录音和合成语音会自动清理，也可以在
-设置中手动清除。
+托盘菜单中的 **Settings… / 设置…** 可以随时打开设置。
 
-如果 macOS 的 GPT-SoVITS Python 环境不在引擎目录内，可将
-`AIPET_GPT_SOVITS_PYTHON` 指向该环境的 Python 可执行文件。
+启用语音输入后，可以分别选择 faster-whisper 模型或仓库 ID、模型下载目录和实际录音输入设备；选择“系统默认”时跟随 Windows 默认输入设备。Windows 上的新配置默认使用 `C:\AIpet\models` 下的独立 Whisper、GPT-SoVITS 和丛雨语音模型目录；已有的自定义路径不会被覆盖。下载和加载都严格使用填写的目录，下载进度、大小和当前文件直接显示在语音设置卡片中，关闭设置后下载仍会继续。
 
-## 桌宠操作
+- **语言模型**：界面语言、后端模式、服务商、URL、对话模型、DeepSeek 思考模式、Ollama 上下文长度、超时和连接测试。
+- **拓展功能 / 屏幕视觉**：独立选择本地 Ollama、阿里云或 OpenAI 视觉后端及模型。
+- **Character**：用户名、默认立绘组、默认服装和人格提示词编辑器。
+- **自动行为**：设置空闲提醒、历史长度和可持久化的勿扰模式，也可以在确认后立即清除对话及屏幕事件记忆。
+- **显示**：选择显示器、立绘比例和实时日志窗口。
 
-| 操作 | 控制方式 |
-|---|---|
-| 输入消息 | 左键单击角色下半部分，输入后按 Enter |
-| 取消输入 | 按 Escape |
-| 摸头 | 在头部按住鼠标左键并横向移动 |
-| 移动桌宠 | 按住鼠标中键拖动 |
-| 语音对话 | 长按 Option+V 两秒 |
-| 设置、视觉、勿扰、记忆、退出 | 使用系统托盘菜单 |
+程序会自动添加结构化输出规则，所以人格提示词只需要描述身份、说话风格、关系和边界。
 
-把桌宠拖到另一台显示器后，程序会自动更新显示器和立绘比例。
-macOS 原生全屏窗口保持相同的操作方式。
+打开设置时会按已启用的功能加载模型列表：Ollama 调用 `GET /api/tags`，云端服务调用 OpenAI 兼容的 `GET /models`。屏幕视觉未启用时不会加载视觉模型列表。修改地址、服务商或 API Key 后，可以点击对应按钮重新测试和刷新。所有模型下拉框都可以直接编辑，因此模型列表接口失败、漏掉自定义模型或服务商未返回完整列表时，仍可手动填写。
+
+DeepSeek 已更新为 V4 接口模型名：`deepseek-v4-flash` 和 `deepseek-v4-pro`。旧配置中的 `deepseek-chat`、`deepseek-reasoner` 会自动迁移，并可以在界面中切换思考模式。
 
 ## 数据与隐私
 
-macOS 上的持久化数据及日志位于 `~/.config/AIpet-Murasame/`，运行缓存位于
-其 `cache/` 子目录，下载模型默认位于项目的 `models/` 目录。AutoDL 密码
-保存在 macOS 钥匙串中。
-
-在设置中填写的 API Key 会写入 `config.json`。如果不希望密钥进入配置文件，
-请把密钥字段留空并使用环境变量。日志会对已识别的密钥字段脱敏，并把大型
-Base64 媒体替换成元数据。
-
-## 开发
-
-macOS 上运行：
-
-```zsh
-QT_QPA_PLATFORM=offscreen .venv/bin/python -m unittest discover -s tests -v
-```
-
-主要目录：
+Windows 下的用户数据位于：
 
 ```text
-classes\    桌宠交互、后台任务和下载
-tool\       模型后端、配置、存储、语音和诊断
-ui\         中英双语设置窗口
-native_overlay/  macOS 原生全屏及输入桥接
-packaging\  可重复执行的 PyInstaller 构建
-tests\      单元测试和 UI 冒烟测试
+%APPDATA%\AIpet-Murasame\
+├── config.json
+├── history.json
+├── screen_memory.json
+└── personality.txt
+```
+
+临时语音和截图仍位于 `%LOCALAPPDATA%\AIpet-Murasame\cache`；Whisper 和 TTS 的新下载位置由用户在设置页分别指定。屏幕感知默认关闭；启用后，截图只会发送给当前配置的视觉模型。程序最多保存最近 12 条显著屏幕事件摘要，并在对话中按字符预算注入最近最多 8 条；连续相同事件会去重，原始截图不会持久化。
+
+通过设置窗口填写的 Key 会保存在用户配置中。如果希望进一步分离凭据，可以把 Key 字段留空并使用 `DEEPSEEK_API_KEY`、`DASHSCOPE_API_KEY` 或 `OPENAI_API_KEY` 环境变量。
+
+## GPT-SoVITS 与语音输入
+
+默认 TTS 地址为：
+
+```text
+http://127.0.0.1:9880/tts
+```
+
+六组参考音频统一放在角色语音模型目录内的 `reference_voices` 子目录中，因此只需填写角色语音模型目录。
+
+本地地址启用 TTS 后，AIpet 会依次检查 GPT-SoVITS 引擎目录、丛雨 GPT/SoVITS 权重、六组参考音频和服务状态。两个现有路径框同时也是实际下载目标：引擎解压到 GPT-SoVITS 目录，角色权重和参考音频下载到角色语音模型目录；所需路径为空时会提示用户先选择，不再静默改用项目默认目录。未检测到 GPT-SoVITS 时，程序会读取 NVIDIA 显卡名称：GeForce RTX 50 系列下载专用整合包，其他显卡或无法识别时下载通用整合包。设置卡片会分别显示准备、校验、下载、解压、安装和清理阶段；解压优先使用开启多线程的原生 7-Zip，找不到时使用 Windows bsdtar，安装时通过同盘原子移动避免再次复制整个目录。所有自动下载均不会打开网页。角色权重来自 `LemonQu/Murasame_SoVITS`，参考音频来自 `kuxiaowo/Murasame-tts-reference-voice`。
+
+首次发起本地 TTS 请求时，如果服务尚未运行，AIpet 会使用引擎自带的 Python 启动 `api_v2.py`，等待 OpenAPI 接口就绪，加载角色权重，再继续合成。设置页也可以手动启动或停止服务，并逐步显示定位环境、启动进程、等待接口和加载权重等状态。并发请求不会重复启动服务；退出程序时只关闭由本次 AIpet 进程启动的服务。远程 TTS 只检查接口状态，不会在本机启动、停止或修改远程服务。
+
+Caps Lock 语音输入是可选功能，需要额外安装：
+
+```bash
+python -m pip install -r requirements-voice.txt
+```
+
+## 操作方式
+
+| 操作 | 方式 |
+|---|---|
+| 输入消息 | 左键点击角色下半部分，输入后按 Enter |
+| 取消输入 | 按 Escape |
+| 摸头 | 在头部按住左键并横向移动 |
+| 移动桌宠 | 按住鼠标中键拖动 |
+| 语音输入 | 启用可选语音功能后长按 Caps Lock 两秒 |
+| 设置、视觉、勿扰、记忆、退出 | 使用系统托盘菜单 |
+
+## 测试
+
+在 Conda 环境中运行：
+
+```bash
+$env:QT_QPA_PLATFORM = "offscreen"
+python -m unittest discover -s tests -v
 ```
 
 ## 已知限制
 
-- 独占全屏或受反作弊保护的画面仍可能覆盖桌宠。
-- macOS 辅助组件面向 Apple Silicon，并在首次启动时于本机编译。
-- Apple Silicon 上的 faster-whisper 使用 CPU。
-- 本地对话、视觉与 TTS 的速度取决于模型和硬件。
-- 角色立绘与语音素材的使用条款可能不同于源代码许可证。
+- 桌面行为主要面向 Windows 开发和测试。
+- 对话和视觉凭据分别配置；如果两者使用同一个云服务，可以在两个面板填写同一个 Key，或使用对应环境变量。
+- HTTP 请求采用协作式取消：旧请求可能在后台结束，但结果会被丢弃，不会覆盖新对话。
+- 角色立绘和语音素材的授权范围可能不同于源代码许可证。
 
-## 致谢与许可证
+## 许可证与素材声明
 
-- 原作桌宠项目：
-  [LemonQu-GIT/MurasamePet](https://github.com/LemonQu-GIT/MurasamePet)
-- AIpet V2 原项目：
-  [kuxiaowo/AIpet-Murasame](https://github.com/kuxiaowo/AIpet-Murasame)
-- 语音合成项目：
-  [RVC-Boss/GPT-SoVITS](https://github.com/RVC-Boss/GPT-SoVITS)
+源代码使用 [GNU Affero General Public License v3.0](../../LICENSE)。
 
-源代码依据
-[GNU Affero General Public License v3.0](../../LICENSE)
-发布。
-
-本项目是用于学习与技术交流的非官方同人项目。丛雨以及项目包含的第三方立绘、
-语音和其他相关素材，其权利归 YUZUSOFT 等各自权利人所有，不因 AGPL
-源代码许可证而被重新授权。未经许可，请勿将这些素材用于商业用途。
+这是用于学习和技术交流的非官方同人项目。丛雨及随附的第三方立绘、语音等素材权利归包括 YUZUSOFT 在内的各自权利人所有，不因源代码使用 AGPL 而被重新许可。未经许可请勿商用相关素材。

--- a/install_macos_tts.command
+++ b/install_macos_tts.command
@@ -1,0 +1,49 @@
+#!/bin/zsh
+
+set -e
+
+PROJECT_ROOT="${0:A:h}"
+ENGINE_ROOT="$PROJECT_ROOT/models/tts/GPT-SoVITS"
+RUNTIME_ROOT="${AIPET_TTS_RUNTIME_DIR:-$HOME/.local/share/AIpet-Murasame/gpt-sovits}"
+CONDA_ROOT="$RUNTIME_ROOT/miniforge3"
+ENV_ROOT="$RUNTIME_ROOT/env"
+MINIFORGE="$RUNTIME_ROOT/Miniforge3-MacOSX-arm64.sh"
+MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh"
+
+if [[ "$(uname -m)" != "arm64" ]]; then
+  echo "此 macOS 安装脚本面向 Apple Silicon（arm64）。"
+  exit 1
+fi
+
+if [[ ! -f "$ENGINE_ROOT/api_v2.py" ]]; then
+  echo "正在下载 GPT-SoVITS 官方源码…"
+  mkdir -p "$ENGINE_ROOT"
+  git clone https://github.com/RVC-Boss/GPT-SoVITS.git "$ENGINE_ROOT"
+fi
+
+if [[ ! -x "$CONDA_ROOT/bin/conda" ]]; then
+  echo "正在下载用户目录内的 Miniforge…"
+  mkdir -p "$RUNTIME_ROOT"
+  curl -L --fail --retry 3 "$MINIFORGE_URL" -o "$MINIFORGE"
+  bash "$MINIFORGE" -b -p "$CONDA_ROOT"
+fi
+
+source "$CONDA_ROOT/etc/profile.d/conda.sh"
+if [[ ! -x "$ENV_ROOT/bin/python" ]]; then
+  echo "正在创建 GPT-SoVITS 环境…"
+  conda create -y -p "$ENV_ROOT" python=3.10
+fi
+conda activate "$ENV_ROOT"
+
+echo "正在准备下载工具和 GPT-SoVITS 依赖…"
+conda install -y -c conda-forge wget
+cd "$ENGINE_ROOT"
+WORKFLOW=true bash install.sh --device CPU --source ModelScope
+python -m pip install torchcodec
+
+echo ""
+echo "GPT-SoVITS 安装完成。"
+echo "引擎目录：$ENGINE_ROOT"
+echo "Python 环境：$ENV_ROOT/bin/python"
+echo "请回到桌宠设置，点击“下载角色语音模型”，然后启动本地 TTS。"
+read -r "?按回车关闭此窗口："

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from pathlib import Path
+import subprocess
 
 from PyQt5.QtCore import QObject, QTimer, pyqtSignal
 from PyQt5.QtGui import QFont, QIcon
@@ -28,7 +28,6 @@ from tool.runtime_logging import (
     get_logger,
     shutdown_console_logging,
 )
-from tool.macos_overlay import MacOSFullscreenOverlay
 from ui.settings_dialog import SettingsDialog
 from tool.tts_service import shutdown_tts_service
 
@@ -66,23 +65,6 @@ UI_TEXT = {
 }
 
 
-def run_special_mode(argv: list[str] | None = None) -> int | None:
-    args = sys.argv if argv is None else argv
-    if len(args) < 2 or args[1] != "--log-viewer":
-        return None
-    if len(args) != 4:
-        return 2
-    try:
-        parent_process_id = int(args[3])
-    except ValueError:
-        return 2
-
-    from tool.log_viewer import follow
-
-    follow(Path(args[2]), parent_process_id)
-    return 0
-
-
 def ui_text(settings: AppSettings, key: str, **values: object) -> str:
     language = (
         settings.ui_language
@@ -98,6 +80,103 @@ class VoiceBridge(QObject):
     record_start = pyqtSignal()
     record_end = pyqtSignal()
     error = pyqtSignal(str)
+
+
+class MacNativeOverlay:
+    """Keep the standard Qt pet visible in macOS fullscreen Spaces."""
+
+    def __init__(self, app: QApplication, pet: Murasame) -> None:
+        self.app = app
+        self.pet = pet
+        self.process: subprocess.Popen[bytes] | None = None
+        self.fullscreen = False
+        self.command_mtime = 0
+        self.directory = pet.native_overlay_directory
+        self.state_path = self.directory / "fullscreen.state"
+        self.visibility_path = self.directory / "qt_visible.state"
+        self.command_path = self.directory / "command.txt"
+        self.timer = QTimer(app)
+        self.timer.setInterval(100)
+        self.timer.timeout.connect(self.sync)
+
+    def start(self) -> None:
+        if sys.platform != "darwin":
+            return
+        binary = PROJECT_ROOT / ".native_overlay" / "murasame_overlay"
+        portrait = self.directory / "portrait.png"
+        if not binary.is_file() or not portrait.is_file():
+            logger.warning("macOS 全屏兼容组件不可用，继续使用普通桌宠窗口")
+            return
+        self.directory.mkdir(parents=True, exist_ok=True)
+        self.command_path.write_text("", encoding="utf-8")
+        self._write_qt_visibility()
+        self.process = subprocess.Popen(
+            [
+                str(binary),
+                str(portrait),
+                str(self.directory / "text.txt"),
+                str(self.state_path),
+                str(self.visibility_path),
+                str(self.command_path),
+            ],
+            cwd=str(PROJECT_ROOT),
+        )
+        self.timer.start()
+        logger.info("macOS 原生全屏兼容组件已启动")
+
+    def sync(self) -> None:
+        if self.process is None or self.process.poll() is not None:
+            self.timer.stop()
+            return
+        self._write_qt_visibility()
+        self._consume_command()
+        try:
+            fullscreen = self.state_path.read_text(encoding="utf-8").strip() == "1"
+        except OSError:
+            fullscreen = False
+        if fullscreen == self.fullscreen:
+            return
+        self.fullscreen = fullscreen
+        if fullscreen:
+            self.pet.hide()
+            self._write_qt_visibility()
+            logger.info("已切换至 macOS 全屏兼容窗口")
+        else:
+            self.pet.show()
+            self._write_qt_visibility()
+            logger.info("已恢复 Qt 桌宠窗口")
+
+    def _consume_command(self) -> None:
+        try:
+            modified = self.command_path.stat().st_mtime_ns
+            if modified <= self.command_mtime:
+                return
+            self.command_mtime = modified
+            text = self.command_path.read_text(encoding="utf-8").strip()
+            if text:
+                self.command_path.write_text("", encoding="utf-8")
+                self.pet.start_thread(text, role="user")
+        except (OSError, UnicodeError):
+            pass
+
+    def _write_qt_visibility(self) -> None:
+        try:
+            self.visibility_path.write_text(
+                "1\n" if self.pet.isVisible() else "0\n",
+                encoding="utf-8",
+            )
+        except OSError:
+            pass
+
+    def stop(self) -> None:
+        self.timer.stop()
+        if self.process is not None and self.process.poll() is None:
+            self.process.terminate()
+            try:
+                self.process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+        self.process = None
 
 
 def load_settings_safely() -> tuple[AppSettings, str | None]:
@@ -154,10 +233,10 @@ def configure_voice_trigger(
 ):
     if not settings.stt.enabled:
         return None
+
     try:
-        from tool.voice_trigger import CapslockVoiceTrigger, MacOSHotkeyVoiceTrigger
+        from tool.voice_trigger import CapslockVoiceTrigger
     except ImportError as exc:
-        logger.exception("语音输入模块加载失败")
         tray_icon.showMessage(
             ui_text(settings, "speech_unavailable"),
             ui_text(settings, "install_voice", error=exc),
@@ -189,10 +268,7 @@ def configure_voice_trigger(
         )
     )
 
-    trigger_class = (
-        MacOSHotkeyVoiceTrigger if sys.platform == "darwin" else CapslockVoiceTrigger
-    )
-    trigger = trigger_class(
+    trigger = CapslockVoiceTrigger(
         on_text_ready=bridge.text_ready.emit,
         hold_seconds=2.0,
         on_record_start=bridge.record_start.emit,
@@ -206,7 +282,6 @@ def configure_voice_trigger(
     try:
         trigger.start()
     except Exception as exc:
-        logger.exception("语音触发器启动失败")
         tray_icon.showMessage(
             ui_text(settings, "speech_failed"),
             str(exc),
@@ -270,8 +345,8 @@ def main() -> int:
         return 1
     pet.show()
     move_pet_to_configured_screen(app, pet, settings)
-    macos_overlay = MacOSFullscreenOverlay(app, pet)
-    macos_overlay.start()
+    native_overlay = MacNativeOverlay(app, pet)
+    native_overlay.start()
 
     tray_icon = QSystemTrayIcon(icon, app)
     tray_menu = QMenu()
@@ -428,7 +503,7 @@ def main() -> int:
 
     def shutdown() -> None:
         logger.info("AIpet 正在退出")
-        macos_overlay.stop()
+        native_overlay.stop()
         if voice_trigger is not None:
             voice_trigger.stop()
         persist_pet_settings()
@@ -444,7 +519,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    special_mode_result = run_special_mode()
-    raise SystemExit(
-        main() if special_mode_result is None else special_mode_result
-    )
+    raise SystemExit(main())

--- a/main.py
+++ b/main.py
@@ -28,6 +28,7 @@ from tool.runtime_logging import (
     get_logger,
     shutdown_console_logging,
 )
+from tool.macos_overlay import MacOSFullscreenOverlay
 from ui.settings_dialog import SettingsDialog
 from tool.tts_service import shutdown_tts_service
 
@@ -153,9 +154,8 @@ def configure_voice_trigger(
 ):
     if not settings.stt.enabled:
         return None
-
     try:
-        from tool.voice_trigger import CapslockVoiceTrigger
+        from tool.voice_trigger import CapslockVoiceTrigger, MacOSHotkeyVoiceTrigger
     except ImportError as exc:
         logger.exception("语音输入模块加载失败")
         tray_icon.showMessage(
@@ -189,7 +189,10 @@ def configure_voice_trigger(
         )
     )
 
-    trigger = CapslockVoiceTrigger(
+    trigger_class = (
+        MacOSHotkeyVoiceTrigger if sys.platform == "darwin" else CapslockVoiceTrigger
+    )
+    trigger = trigger_class(
         on_text_ready=bridge.text_ready.emit,
         hold_seconds=2.0,
         on_record_start=bridge.record_start.emit,
@@ -267,6 +270,8 @@ def main() -> int:
         return 1
     pet.show()
     move_pet_to_configured_screen(app, pet, settings)
+    macos_overlay = MacOSFullscreenOverlay(app, pet)
+    macos_overlay.start()
 
     tray_icon = QSystemTrayIcon(icon, app)
     tray_menu = QMenu()
@@ -423,6 +428,7 @@ def main() -> int:
 
     def shutdown() -> None:
         logger.info("AIpet 正在退出")
+        macos_overlay.stop()
         if voice_trigger is not None:
             voice_trigger.stop()
         persist_pet_settings()

--- a/native_overlay/murasame_overlay.m
+++ b/native_overlay/murasame_overlay.m
@@ -1,0 +1,330 @@
+#import <Cocoa/Cocoa.h>
+#import <CoreGraphics/CoreGraphics.h>
+#import <fcntl.h>
+#import <sys/file.h>
+#import <unistd.h>
+
+static NSString *const HeadPatCommand = @"__murasame_head_pat__";
+
+@interface MurasamePanel : NSPanel <NSTextViewDelegate>
+@property(nonatomic, copy) NSString *imagePath;
+@property(nonatomic, copy) NSString *textPath;
+@property(nonatomic, copy) NSString *statePath;
+@property(nonatomic, copy) NSString *visibilityPath;
+@property(nonatomic, copy) NSString *commandPath;
+@property(nonatomic, strong) NSTextField *textField;
+@property(nonatomic, strong) NSTextView *inputView;
+@property(nonatomic, copy) NSString *latestText;
+@property(nonatomic, strong) NSDate *lastImageDate;
+@property(nonatomic) BOOL fullscreen;
+@property(nonatomic) BOOL qtVisible;
+@property(nonatomic) BOOL shown;
+@property(nonatomic) BOOL dragging;
+@property(nonatomic) BOOL touchingHead;
+@property(nonatomic) NSPoint dragOffset;
+@property(nonatomic) NSPoint headStart;
+@property(nonatomic) BOOL inputMode;
+@end
+
+@implementation MurasamePanel
+
+- (BOOL)canBecomeKeyWindow { return YES; }
+- (BOOL)canBecomeMainWindow { return NO; }
+
+- (void)mouseDown:(NSEvent *)event {
+    if (!self.fullscreen) return;
+    NSPoint point = event.locationInWindow;
+    if (point.y > self.frame.size.height * 0.78) {
+        self.touchingHead = YES;
+        self.headStart = point;
+        return;
+    }
+    if (point.y < self.frame.size.height * 0.62) {
+        self.inputMode = YES;
+        self.level = NSFloatingWindowLevel;
+        self.inputView.hidden = NO;
+        self.inputView.editable = YES;
+        self.inputView.string = @"";
+        [self makeKeyAndOrderFront:nil];
+        [NSApp activateIgnoringOtherApps:YES];
+        [self makeFirstResponder:self.inputView];
+    }
+}
+
+- (void)mouseDragged:(NSEvent *)event {
+    if (!self.touchingHead) return;
+    if (fabs(event.locationInWindow.x - self.headStart.x) > 50.0) {
+        [HeadPatCommand writeToFile:self.commandPath atomically:YES
+                          encoding:NSUTF8StringEncoding error:nil];
+        self.touchingHead = NO;
+    }
+}
+
+- (void)mouseUp:(NSEvent *)event {
+    self.touchingHead = NO;
+}
+
+- (void)otherMouseDown:(NSEvent *)event {
+    if (!self.fullscreen) return;
+    self.dragOffset = event.locationInWindow;
+    self.dragging = YES;
+}
+
+- (void)otherMouseDragged:(NSEvent *)event {
+    if (!self.dragging) return;
+    NSPoint mouse = NSEvent.mouseLocation;
+    [self setFrameOrigin:NSMakePoint(mouse.x - self.dragOffset.x,
+                                     mouse.y - self.dragOffset.y)];
+}
+
+- (void)otherMouseUp:(NSEvent *)event {
+    self.dragging = NO;
+}
+
+- (BOOL)textView:(NSTextView *)textView
+doCommandBySelector:(SEL)selector {
+    if (textView != self.inputView) return NO;
+    if (selector == @selector(insertNewline:)) {
+        NSString *text = [textView.string
+            stringByTrimmingCharactersInSet:
+                NSCharacterSet.whitespaceAndNewlineCharacterSet];
+        if (text.length > 0) {
+            [text writeToFile:self.commandPath atomically:YES
+                     encoding:NSUTF8StringEncoding error:nil];
+        }
+        [self endInput];
+        return YES;
+    }
+    if (selector == @selector(cancelOperation:)) {
+        [self endInput];
+        return YES;
+    }
+    return NO;
+}
+
+- (void)endInput {
+    self.inputMode = NO;
+    self.level = 101;
+    self.inputView.editable = NO;
+    self.inputView.hidden = YES;
+    [self makeFirstResponder:nil];
+}
+
+@end
+
+static BOOL frontmostAppHasFullscreenWindow(void) {
+    NSRunningApplication *frontmost =
+        NSWorkspace.sharedWorkspace.frontmostApplication;
+    if (!frontmost || frontmost.processIdentifier == getpid()) return NO;
+
+    NSArray *windows = CFBridgingRelease(CGWindowListCopyWindowInfo(
+        kCGWindowListOptionOnScreenOnly |
+            kCGWindowListExcludeDesktopElements,
+        kCGNullWindowID));
+    NSRect screen = NSScreen.mainScreen.frame;
+    for (NSDictionary *info in windows) {
+        if ([info[(id)kCGWindowOwnerPID] intValue] !=
+            frontmost.processIdentifier) {
+            continue;
+        }
+        CGRect rect;
+        NSDictionary *bounds = info[(id)kCGWindowBounds];
+        if (!CGRectMakeWithDictionaryRepresentation(
+                (__bridge CFDictionaryRef)bounds, &rect)) {
+            continue;
+        }
+        if (rect.size.width >= screen.size.width * 0.90 &&
+            rect.size.height >= screen.size.height * 0.90) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
+static void writeState(MurasamePanel *panel, BOOL fullscreen) {
+    NSString *value = fullscreen ? @"1\n" : @"0\n";
+    [value writeToFile:panel.statePath atomically:YES
+              encoding:NSUTF8StringEncoding error:nil];
+}
+
+static void reloadQtVisibility(MurasamePanel *panel) {
+    NSString *value = [NSString
+        stringWithContentsOfFile:panel.visibilityPath
+        encoding:NSUTF8StringEncoding error:nil];
+    if (value) panel.qtVisible = value.integerValue != 0;
+}
+
+static NSAttributedString *outlinedText(
+    NSString *text,
+    NSFont *font
+) {
+    return [[NSAttributedString alloc] initWithString:text attributes:@{
+        NSFontAttributeName: font,
+        NSForegroundColorAttributeName: NSColor.whiteColor,
+        NSStrokeColorAttributeName:
+            [NSColor colorWithCalibratedRed:0.17 green:0.09 blue:0.11 alpha:1],
+        NSStrokeWidthAttributeName: @(-3.0),
+    }];
+}
+
+static void reloadText(MurasamePanel *panel) {
+    NSString *text = [NSString stringWithContentsOfFile:panel.textPath
+                                               encoding:NSUTF8StringEncoding
+                                                  error:nil];
+    if (text && ![text isEqualToString:panel.latestText]) {
+        panel.latestText = text;
+        if (!panel.inputMode) {
+            panel.textField.attributedStringValue =
+                outlinedText(text, panel.textField.font);
+        }
+    }
+}
+
+static void reloadImage(MurasamePanel *panel, NSImageView *imageView) {
+    NSDictionary *attributes = [[NSFileManager defaultManager]
+        attributesOfItemAtPath:panel.imagePath error:nil];
+    NSDate *modified = attributes[NSFileModificationDate];
+    if (!modified ||
+        (panel.lastImageDate &&
+         [modified compare:panel.lastImageDate] != NSOrderedDescending)) {
+        return;
+    }
+    NSImage *image =
+        [[NSImage alloc] initWithContentsOfFile:panel.imagePath];
+    if (image) {
+        imageView.image = image;
+        panel.lastImageDate = modified;
+    }
+}
+
+static void tick(MurasamePanel *panel, NSImageView *imageView) {
+    reloadQtVisibility(panel);
+    reloadText(panel);
+    reloadImage(panel, imageView);
+    NSRunningApplication *frontmost =
+        NSWorkspace.sharedWorkspace.frontmostApplication;
+    BOOL fullscreen = frontmost.processIdentifier == getpid()
+        ? panel.fullscreen
+        : frontmostAppHasFullscreenWindow();
+    if (fullscreen != panel.fullscreen) {
+        panel.fullscreen = fullscreen;
+        writeState(panel, fullscreen);
+    }
+
+    BOOL shouldShow = panel.fullscreen;
+    if (shouldShow == panel.shown) return;
+    panel.shown = shouldShow;
+    if (shouldShow) {
+        [panel orderFrontRegardless];
+    } else {
+        [panel orderOut:nil];
+    }
+}
+
+int main(int argc, const char *argv[]) {
+    @autoreleasepool {
+        if (argc < 6) return 2;
+        NSString *imagePath =
+            [NSString stringWithUTF8String:argv[1]];
+        NSString *textPath =
+            [NSString stringWithUTF8String:argv[2]];
+        NSString *statePath =
+            [NSString stringWithUTF8String:argv[3]];
+        NSString *visibilityPath =
+            [NSString stringWithUTF8String:argv[4]];
+        NSString *commandPath =
+            [NSString stringWithUTF8String:argv[5]];
+
+        int lockFD =
+            open(".native_overlay/native_overlay.lock", O_CREAT | O_RDWR, 0600);
+        if (lockFD < 0 || flock(lockFD, LOCK_EX | LOCK_NB) != 0) {
+            return 0;
+        }
+
+        NSImage *image =
+            [[NSImage alloc] initWithContentsOfFile:imagePath];
+        if (!image) return 1;
+        [NSApplication sharedApplication];
+        [NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+
+        NSRect screen = NSScreen.mainScreen.visibleFrame;
+        CGFloat scale =
+            MIN(1.0, screen.size.height / MAX(image.size.height, 1));
+        NSSize size =
+            NSMakeSize(image.size.width * scale, image.size.height * scale);
+        NSRect frame =
+            NSMakeRect(NSMaxX(screen) - size.width - 24,
+                       NSMinY(screen) + 20, size.width, size.height);
+        MurasamePanel *panel = [[MurasamePanel alloc]
+            initWithContentRect:frame
+                      styleMask:NSWindowStyleMaskBorderless
+                        backing:NSBackingStoreBuffered
+                          defer:NO];
+        panel.imagePath = imagePath;
+        panel.textPath = textPath;
+        panel.statePath = statePath;
+        panel.visibilityPath = visibilityPath;
+        panel.commandPath = commandPath;
+        panel.opaque = NO;
+        panel.backgroundColor = NSColor.clearColor;
+        panel.hasShadow = NO;
+        panel.hidesOnDeactivate = NO;
+        panel.becomesKeyOnlyIfNeeded = NO;
+        panel.floatingPanel = YES;
+        panel.level = 101;
+        panel.collectionBehavior =
+            NSWindowCollectionBehaviorCanJoinAllSpaces |
+            NSWindowCollectionBehaviorCanJoinAllApplications |
+            NSWindowCollectionBehaviorFullScreenAuxiliary |
+            NSWindowCollectionBehaviorStationary;
+
+        NSView *root =
+            [[NSView alloc] initWithFrame:NSMakeRect(
+                0, 0, size.width, size.height)];
+        NSImageView *imageView =
+            [[NSImageView alloc] initWithFrame:root.bounds];
+        imageView.image = image;
+        imageView.imageScaling = NSImageScaleProportionallyUpOrDown;
+        [root addSubview:imageView];
+
+        NSRect textFrame =
+            NSMakeRect(18, size.height * 0.42,
+                       size.width - 36, size.height * 0.30);
+        NSTextField *textField =
+            [[NSTextField alloc] initWithFrame:textFrame];
+        textField.bezeled = NO;
+        textField.drawsBackground = NO;
+        textField.font =
+            [NSFont systemFontOfSize:14 weight:NSFontWeightSemibold];
+        textField.editable = NO;
+        textField.selectable = NO;
+        textField.maximumNumberOfLines = 0;
+        textField.lineBreakMode = NSLineBreakByWordWrapping;
+        [root addSubview:textField];
+        panel.textField = textField;
+
+        NSTextView *inputView =
+            [[NSTextView alloc] initWithFrame:textFrame];
+        inputView.editable = NO;
+        inputView.richText = NO;
+        inputView.drawsBackground = NO;
+        inputView.backgroundColor = NSColor.clearColor;
+        inputView.textColor = NSColor.whiteColor;
+        inputView.font = textField.font;
+        inputView.delegate = panel;
+        inputView.hidden = YES;
+        [root addSubview:inputView];
+        panel.inputView = inputView;
+        panel.contentView = root;
+
+        writeState(panel, NO);
+        [NSTimer
+            scheduledTimerWithTimeInterval:0.10
+                                   repeats:YES
+                                     block:^(__unused NSTimer *timer) {
+                tick(panel, imageView);
+            }];
+        [NSApp run];
+    }
+    return 0;
+}

--- a/native_overlay/murasame_overlay.m
+++ b/native_overlay/murasame_overlay.m
@@ -4,8 +4,6 @@
 #import <sys/file.h>
 #import <unistd.h>
 
-static NSString *const HeadPatCommand = @"__murasame_head_pat__";
-
 @interface MurasamePanel : NSPanel <NSTextViewDelegate>
 @property(nonatomic, copy) NSString *imagePath;
 @property(nonatomic, copy) NSString *textPath;
@@ -20,26 +18,17 @@ static NSString *const HeadPatCommand = @"__murasame_head_pat__";
 @property(nonatomic) BOOL qtVisible;
 @property(nonatomic) BOOL shown;
 @property(nonatomic) BOOL dragging;
-@property(nonatomic) BOOL touchingHead;
 @property(nonatomic) NSPoint dragOffset;
-@property(nonatomic) NSPoint headStart;
 @property(nonatomic) BOOL inputMode;
 @end
 
 @implementation MurasamePanel
-
 - (BOOL)canBecomeKeyWindow { return YES; }
 - (BOOL)canBecomeMainWindow { return NO; }
 
 - (void)mouseDown:(NSEvent *)event {
     if (!self.fullscreen) return;
-    NSPoint point = event.locationInWindow;
-    if (point.y > self.frame.size.height * 0.78) {
-        self.touchingHead = YES;
-        self.headStart = point;
-        return;
-    }
-    if (point.y < self.frame.size.height * 0.62) {
+    if (event.locationInWindow.y < self.frame.size.height * 0.38) {
         self.inputMode = YES;
         self.level = NSFloatingWindowLevel;
         self.inputView.hidden = NO;
@@ -49,19 +38,6 @@ static NSString *const HeadPatCommand = @"__murasame_head_pat__";
         [NSApp activateIgnoringOtherApps:YES];
         [self makeFirstResponder:self.inputView];
     }
-}
-
-- (void)mouseDragged:(NSEvent *)event {
-    if (!self.touchingHead) return;
-    if (fabs(event.locationInWindow.x - self.headStart.x) > 50.0) {
-        [HeadPatCommand writeToFile:self.commandPath atomically:YES
-                          encoding:NSUTF8StringEncoding error:nil];
-        self.touchingHead = NO;
-    }
-}
-
-- (void)mouseUp:(NSEvent *)event {
-    self.touchingHead = NO;
 }
 
 - (void)otherMouseDown:(NSEvent *)event {
@@ -77,20 +53,17 @@ static NSString *const HeadPatCommand = @"__murasame_head_pat__";
                                      mouse.y - self.dragOffset.y)];
 }
 
-- (void)otherMouseUp:(NSEvent *)event {
-    self.dragging = NO;
-}
+- (void)otherMouseUp:(NSEvent *)event { self.dragging = NO; }
 
 - (BOOL)textView:(NSTextView *)textView
 doCommandBySelector:(SEL)selector {
     if (textView != self.inputView) return NO;
     if (selector == @selector(insertNewline:)) {
         NSString *text = [textView.string
-            stringByTrimmingCharactersInSet:
-                NSCharacterSet.whitespaceAndNewlineCharacterSet];
+            stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
         if (text.length > 0) {
             [text writeToFile:self.commandPath atomically:YES
-                     encoding:NSUTF8StringEncoding error:nil];
+                      encoding:NSUTF8StringEncoding error:nil];
         }
         [self endInput];
         return YES;
@@ -109,34 +82,22 @@ doCommandBySelector:(SEL)selector {
     self.inputView.hidden = YES;
     [self makeFirstResponder:nil];
 }
-
 @end
 
 static BOOL frontmostAppHasFullscreenWindow(void) {
-    NSRunningApplication *frontmost =
-        NSWorkspace.sharedWorkspace.frontmostApplication;
+    NSRunningApplication *frontmost = NSWorkspace.sharedWorkspace.frontmostApplication;
     if (!frontmost || frontmost.processIdentifier == getpid()) return NO;
-
     NSArray *windows = CFBridgingRelease(CGWindowListCopyWindowInfo(
-        kCGWindowListOptionOnScreenOnly |
-            kCGWindowListExcludeDesktopElements,
+        kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements,
         kCGNullWindowID));
     NSRect screen = NSScreen.mainScreen.frame;
     for (NSDictionary *info in windows) {
-        if ([info[(id)kCGWindowOwnerPID] intValue] !=
-            frontmost.processIdentifier) {
-            continue;
-        }
+        if ([info[(id)kCGWindowOwnerPID] intValue] != frontmost.processIdentifier) continue;
         CGRect rect;
         NSDictionary *bounds = info[(id)kCGWindowBounds];
-        if (!CGRectMakeWithDictionaryRepresentation(
-                (__bridge CFDictionaryRef)bounds, &rect)) {
-            continue;
-        }
+        if (!CGRectMakeWithDictionaryRepresentation((__bridge CFDictionaryRef)bounds, &rect)) continue;
         if (rect.size.width >= screen.size.width * 0.90 &&
-            rect.size.height >= screen.size.height * 0.90) {
-            return YES;
-        }
+            rect.size.height >= screen.size.height * 0.90) return YES;
     }
     return NO;
 }
@@ -148,35 +109,19 @@ static void writeState(MurasamePanel *panel, BOOL fullscreen) {
 }
 
 static void reloadQtVisibility(MurasamePanel *panel) {
-    NSString *value = [NSString
-        stringWithContentsOfFile:panel.visibilityPath
-        encoding:NSUTF8StringEncoding error:nil];
-    if (value) panel.qtVisible = value.integerValue != 0;
-}
-
-static NSAttributedString *outlinedText(
-    NSString *text,
-    NSFont *font
-) {
-    return [[NSAttributedString alloc] initWithString:text attributes:@{
-        NSFontAttributeName: font,
-        NSForegroundColorAttributeName: NSColor.whiteColor,
-        NSStrokeColorAttributeName:
-            [NSColor colorWithCalibratedRed:0.17 green:0.09 blue:0.11 alpha:1],
-        NSStrokeWidthAttributeName: @(-3.0),
-    }];
+    NSString *value = [NSString stringWithContentsOfFile:panel.visibilityPath
+                                                 encoding:NSUTF8StringEncoding error:nil];
+    if (value) {
+        panel.qtVisible = value.integerValue != 0;
+    }
 }
 
 static void reloadText(MurasamePanel *panel) {
     NSString *text = [NSString stringWithContentsOfFile:panel.textPath
-                                               encoding:NSUTF8StringEncoding
-                                                  error:nil];
+                                                encoding:NSUTF8StringEncoding error:nil];
     if (text && ![text isEqualToString:panel.latestText]) {
         panel.latestText = text;
-        if (!panel.inputMode) {
-            panel.textField.attributedStringValue =
-                outlinedText(text, panel.textField.font);
-        }
+        if (!panel.inputMode) panel.textField.stringValue = text;
     }
 }
 
@@ -184,13 +129,9 @@ static void reloadImage(MurasamePanel *panel, NSImageView *imageView) {
     NSDictionary *attributes = [[NSFileManager defaultManager]
         attributesOfItemAtPath:panel.imagePath error:nil];
     NSDate *modified = attributes[NSFileModificationDate];
-    if (!modified ||
-        (panel.lastImageDate &&
-         [modified compare:panel.lastImageDate] != NSOrderedDescending)) {
-        return;
-    }
-    NSImage *image =
-        [[NSImage alloc] initWithContentsOfFile:panel.imagePath];
+    if (!modified || (panel.lastImageDate &&
+                      [modified compare:panel.lastImageDate] != NSOrderedDescending)) return;
+    NSImage *image = [[NSImage alloc] initWithContentsOfFile:panel.imagePath];
     if (image) {
         imageView.image = image;
         panel.lastImageDate = modified;
@@ -201,65 +142,43 @@ static void tick(MurasamePanel *panel, NSImageView *imageView) {
     reloadQtVisibility(panel);
     reloadText(panel);
     reloadImage(panel, imageView);
-    NSRunningApplication *frontmost =
-        NSWorkspace.sharedWorkspace.frontmostApplication;
+    NSRunningApplication *frontmost = NSWorkspace.sharedWorkspace.frontmostApplication;
     BOOL fullscreen = frontmost.processIdentifier == getpid()
-        ? panel.fullscreen
-        : frontmostAppHasFullscreenWindow();
+        ? panel.fullscreen : frontmostAppHasFullscreenWindow();
     if (fullscreen != panel.fullscreen) {
         panel.fullscreen = fullscreen;
         writeState(panel, fullscreen);
     }
-
-    BOOL shouldShow = panel.fullscreen;
+    BOOL shouldShow = panel.fullscreen && !panel.qtVisible;
     if (shouldShow == panel.shown) return;
     panel.shown = shouldShow;
-    if (shouldShow) {
-        [panel orderFrontRegardless];
-    } else {
-        [panel orderOut:nil];
-    }
+    if (shouldShow) [panel orderFrontRegardless]; else [panel orderOut:nil];
 }
 
 int main(int argc, const char *argv[]) {
     @autoreleasepool {
         if (argc < 6) return 2;
-        NSString *imagePath =
-            [NSString stringWithUTF8String:argv[1]];
-        NSString *textPath =
-            [NSString stringWithUTF8String:argv[2]];
-        NSString *statePath =
-            [NSString stringWithUTF8String:argv[3]];
-        NSString *visibilityPath =
-            [NSString stringWithUTF8String:argv[4]];
-        NSString *commandPath =
-            [NSString stringWithUTF8String:argv[5]];
+        NSString *imagePath = [NSString stringWithUTF8String:argv[1]];
+        NSString *textPath = [NSString stringWithUTF8String:argv[2]];
+        NSString *statePath = [NSString stringWithUTF8String:argv[3]];
+        NSString *visibilityPath = [NSString stringWithUTF8String:argv[4]];
+        NSString *commandPath = [NSString stringWithUTF8String:argv[5]];
+        int lockFD = open(".native_overlay.lock", O_CREAT | O_RDWR, 0600);
+        if (lockFD < 0 || flock(lockFD, LOCK_EX | LOCK_NB) != 0) return 0;
 
-        int lockFD =
-            open(".native_overlay/native_overlay.lock", O_CREAT | O_RDWR, 0600);
-        if (lockFD < 0 || flock(lockFD, LOCK_EX | LOCK_NB) != 0) {
-            return 0;
-        }
-
-        NSImage *image =
-            [[NSImage alloc] initWithContentsOfFile:imagePath];
+        NSImage *image = [[NSImage alloc] initWithContentsOfFile:imagePath];
         if (!image) return 1;
         [NSApplication sharedApplication];
         [NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
 
         NSRect screen = NSScreen.mainScreen.visibleFrame;
-        CGFloat scale =
-            MIN(1.0, screen.size.height / MAX(image.size.height, 1));
-        NSSize size =
-            NSMakeSize(image.size.width * scale, image.size.height * scale);
-        NSRect frame =
-            NSMakeRect(NSMaxX(screen) - size.width - 24,
-                       NSMinY(screen) + 20, size.width, size.height);
+        CGFloat scale = MIN(1.0, screen.size.height / MAX(image.size.height, 1));
+        NSSize size = NSMakeSize(image.size.width * scale, image.size.height * scale);
+        NSRect frame = NSMakeRect(NSMaxX(screen) - size.width - 24,
+                                  NSMinY(screen) + 20, size.width, size.height);
         MurasamePanel *panel = [[MurasamePanel alloc]
-            initWithContentRect:frame
-                      styleMask:NSWindowStyleMaskBorderless
-                        backing:NSBackingStoreBuffered
-                          defer:NO];
+            initWithContentRect:frame styleMask:NSWindowStyleMaskBorderless
+            backing:NSBackingStoreBuffered defer:NO];
         panel.imagePath = imagePath;
         panel.textPath = textPath;
         panel.statePath = statePath;
@@ -272,30 +191,23 @@ int main(int argc, const char *argv[]) {
         panel.becomesKeyOnlyIfNeeded = NO;
         panel.floatingPanel = YES;
         panel.level = 101;
-        panel.collectionBehavior =
-            NSWindowCollectionBehaviorCanJoinAllSpaces |
+        panel.collectionBehavior = NSWindowCollectionBehaviorCanJoinAllSpaces |
             NSWindowCollectionBehaviorCanJoinAllApplications |
             NSWindowCollectionBehaviorFullScreenAuxiliary |
             NSWindowCollectionBehaviorStationary;
 
-        NSView *root =
-            [[NSView alloc] initWithFrame:NSMakeRect(
-                0, 0, size.width, size.height)];
-        NSImageView *imageView =
-            [[NSImageView alloc] initWithFrame:root.bounds];
+        NSView *root = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, size.width, size.height)];
+        NSImageView *imageView = [[NSImageView alloc] initWithFrame:root.bounds];
         imageView.image = image;
         imageView.imageScaling = NSImageScaleProportionallyUpOrDown;
         [root addSubview:imageView];
 
-        NSRect textFrame =
-            NSMakeRect(18, size.height * 0.42,
-                       size.width - 36, size.height * 0.30);
-        NSTextField *textField =
-            [[NSTextField alloc] initWithFrame:textFrame];
+        NSRect textFrame = NSMakeRect(18, size.height * 0.42, size.width - 36, size.height * 0.28);
+        NSTextField *textField = [[NSTextField alloc] initWithFrame:textFrame];
         textField.bezeled = NO;
         textField.drawsBackground = NO;
-        textField.font =
-            [NSFont systemFontOfSize:14 weight:NSFontWeightSemibold];
+        textField.textColor = NSColor.whiteColor;
+        textField.font = [NSFont systemFontOfSize:14 weight:NSFontWeightMedium];
         textField.editable = NO;
         textField.selectable = NO;
         textField.maximumNumberOfLines = 0;
@@ -303,8 +215,7 @@ int main(int argc, const char *argv[]) {
         [root addSubview:textField];
         panel.textField = textField;
 
-        NSTextView *inputView =
-            [[NSTextView alloc] initWithFrame:textFrame];
+        NSTextView *inputView = [[NSTextView alloc] initWithFrame:textFrame];
         inputView.editable = NO;
         inputView.richText = NO;
         inputView.drawsBackground = NO;
@@ -318,12 +229,9 @@ int main(int argc, const char *argv[]) {
         panel.contentView = root;
 
         writeState(panel, NO);
-        [NSTimer
-            scheduledTimerWithTimeInterval:0.10
-                                   repeats:YES
-                                     block:^(__unused NSTimer *timer) {
-                tick(panel, imageView);
-            }];
+        [NSTimer scheduledTimerWithTimeInterval:0.10 repeats:YES block:^(__unused NSTimer *timer) {
+            tick(panel, imageView);
+        }];
         [NSApp run];
     }
     return 0;

--- a/requirements-voice.txt
+++ b/requirements-voice.txt
@@ -2,3 +2,4 @@
 faster-whisper>=1.1,<2
 pynput>=1.7,<2
 sounddevice>=0.5,<1
+pyobjc-framework-Quartz>=11,<12; sys_platform == "darwin"

--- a/start_macos.command
+++ b/start_macos.command
@@ -6,33 +6,18 @@ SCRIPT_DIR="${0:A:h}"
 cd "$SCRIPT_DIR"
 
 PYTHON_BIN="$(command -v python3.10 || command -v python3)"
-if [[ -z "$PYTHON_BIN" ]]; then
-  echo "需要 Python 3.10 或更高版本。"
-  exit 1
-fi
-if ! "$PYTHON_BIN" -c 'import sys; raise SystemExit(sys.version_info < (3, 10))'; then
-  echo "当前 Python 版本过低，需要 Python 3.10 或更高版本。"
-  exit 1
-fi
-
 if [[ ! -x ".venv/bin/python" ]]; then
-  echo "正在创建 macOS Python 环境…"
+  echo "正在创建 Python 环境…"
   "$PYTHON_BIN" -m venv .venv
   .venv/bin/python -m pip install --upgrade pip
-  .venv/bin/python -m pip install -r requirements-voice.txt
+  .venv/bin/python -m pip install -r requirements.txt
 fi
 
-SOURCE="native_overlay/murasame_overlay.m"
-BINARY=".native_overlay/murasame_overlay"
-if [[ ! -x "$BINARY" || "$SOURCE" -nt "$BINARY" ]]; then
-  if ! command -v clang >/dev/null; then
-    echo "缺少 Xcode Command Line Tools，请先运行：xcode-select --install"
-    exit 1
-  fi
+if [[ -f "native_overlay/murasame_overlay.m" && ( ! -x ".native_overlay/murasame_overlay" || "native_overlay/murasame_overlay.m" -nt ".native_overlay/murasame_overlay" ) ]]; then
   mkdir -p .native_overlay
   echo "正在编译 macOS 全屏兼容组件…"
   clang -fobjc-arc -framework Cocoa -framework CoreGraphics \
-    "$SOURCE" -o "$BINARY"
+    native_overlay/murasame_overlay.m -o .native_overlay/murasame_overlay
 fi
 
 exec .venv/bin/python main.py

--- a/start_macos.command
+++ b/start_macos.command
@@ -1,0 +1,38 @@
+#!/bin/zsh
+
+set -e
+
+SCRIPT_DIR="${0:A:h}"
+cd "$SCRIPT_DIR"
+
+PYTHON_BIN="$(command -v python3.10 || command -v python3)"
+if [[ -z "$PYTHON_BIN" ]]; then
+  echo "需要 Python 3.10 或更高版本。"
+  exit 1
+fi
+if ! "$PYTHON_BIN" -c 'import sys; raise SystemExit(sys.version_info < (3, 10))'; then
+  echo "当前 Python 版本过低，需要 Python 3.10 或更高版本。"
+  exit 1
+fi
+
+if [[ ! -x ".venv/bin/python" ]]; then
+  echo "正在创建 macOS Python 环境…"
+  "$PYTHON_BIN" -m venv .venv
+  .venv/bin/python -m pip install --upgrade pip
+  .venv/bin/python -m pip install -r requirements-voice.txt
+fi
+
+SOURCE="native_overlay/murasame_overlay.m"
+BINARY=".native_overlay/murasame_overlay"
+if [[ ! -x "$BINARY" || "$SOURCE" -nt "$BINARY" ]]; then
+  if ! command -v clang >/dev/null; then
+    echo "缺少 Xcode Command Line Tools，请先运行：xcode-select --install"
+    exit 1
+  fi
+  mkdir -p .native_overlay
+  echo "正在编译 macOS 全屏兼容组件…"
+  clang -fobjc-arc -framework Cocoa -framework CoreGraphics \
+    "$SOURCE" -o "$BINARY"
+fi
+
+exec .venv/bin/python main.py

--- a/tests/test_autodl_tts.py
+++ b/tests/test_autodl_tts.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import os
+import sys
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from tool.autodl_tts import (
     AutoDLConnectionError,
@@ -73,6 +74,22 @@ class AutoDLTTSTests(unittest.TestCase):
             unprotect_secret(token),
             "temporary-password",
         )
+
+    @unittest.skipUnless(sys.platform == "darwin", "macOS Keychain is required")
+    def test_password_round_trip_uses_macos_keychain(self) -> None:
+        saved = Mock(returncode=0, stdout="", stderr="")
+        loaded = Mock(returncode=0, stdout="temporary-password\n", stderr="")
+        with patch(
+            "tool.credentials.subprocess.run",
+            side_effect=[saved, loaded],
+        ) as run:
+            token = protect_secret("temporary-password")
+            password = unprotect_secret(token)
+
+        self.assertEqual(token, "keychain:AutoDL")
+        self.assertNotIn("temporary-password", token)
+        self.assertEqual(password, "temporary-password")
+        self.assertEqual(run.call_count, 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ctypes
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -417,6 +418,7 @@ class CoreTests(unittest.TestCase):
         self.assertEqual(migrated.vision.aliyun_model, "legacy-vl")
         self.assertEqual(migrated.vision.timeout_seconds, 90)
 
+    @unittest.skipUnless(os.name == "nt", "Windows path migration")
     def test_legacy_managed_tts_paths_move_to_project_models(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import Mock, patch
+
+import main
+from tool.config import AppSettings, STTSettings
+
+
+class MainTests(unittest.TestCase):
+    def test_macos_uses_native_hotkey_voice_trigger(self) -> None:
+        settings = AppSettings(stt=STTSettings(enabled=True))
+        fake_trigger = Mock()
+        fake_trigger.return_value.start.return_value = None
+        fake_bridge = Mock()
+        with patch.object(main.sys, "platform", "darwin"):
+            with patch("main.VoiceBridge", return_value=fake_bridge):
+                with patch("tool.voice_trigger.MacOSHotkeyVoiceTrigger", fake_trigger):
+                    trigger = main.configure_voice_trigger(Mock(), settings, Mock())
+        self.assertIs(trigger, fake_trigger.return_value)
+        fake_trigger.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime_logging.py
+++ b/tests/test_runtime_logging.py
@@ -138,7 +138,7 @@ class RuntimeLoggingTests(unittest.TestCase):
             [
                 "python.exe",
                 str(runtime_logging.LOG_VIEWER),
-                "C:\\logs",
+                str(Path("C:/logs")),
                 "123",
             ],
         )
@@ -157,7 +157,7 @@ class RuntimeLoggingTests(unittest.TestCase):
 
         self.assertEqual(
             command,
-            ["AIpet.exe", "--log-viewer", "C:\\logs", "123"],
+            ["AIpet.exe", "--log-viewer", str(Path("C:/logs")), "123"],
         )
 
     def test_main_dispatches_log_viewer_special_mode(self) -> None:

--- a/tests/test_tts_service.py
+++ b/tests/test_tts_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -27,7 +28,11 @@ class TTSServiceTests(unittest.TestCase):
 
             self.assertEqual(
                 Path(command[0]),
-                (engine / "runtime" / "python.exe").resolve(),
+                (
+                    engine
+                    / "runtime"
+                    / ("python.exe" if os.name == "nt" else "python")
+                ).resolve(),
             )
             self.assertEqual(Path(command[1]), engine / "api_v2.py")
             self.assertEqual(command[-4:], ["-p", "9880", "-c", command[-1]])
@@ -42,13 +47,45 @@ class TTSServiceTests(unittest.TestCase):
     def test_build_command_requires_engine_python_runtime(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             engine = self._create_engine(Path(directory))
-            (engine / "runtime" / "python.exe").unlink()
+            (
+                engine
+                / "runtime"
+                / ("python.exe" if os.name == "nt" else "python")
+            ).unlink()
 
-            with self.assertRaisesRegex(
-                TTSServiceError,
-                "does not contain a bundled Python runtime",
+            with (
+                patch("tool.tts_service.Path.home", return_value=Path(directory)),
+                self.assertRaisesRegex(
+                    TTSServiceError,
+                    "does not contain a bundled Python runtime",
+                ),
             ):
                 _build_start_command(engine, ("127.0.0.1", 9880))
+
+    @unittest.skipUnless(sys.platform == "darwin", "macOS runtime layout")
+    def test_build_command_finds_mac_user_runtime(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            engine = self._create_engine(Path(directory))
+            (engine / "runtime" / "python").unlink()
+            with tempfile.TemporaryDirectory() as home:
+                runtime = (
+                    Path(home)
+                    / ".local"
+                    / "share"
+                    / "AIpet-Murasame"
+                    / "gpt-sovits"
+                    / "env"
+                    / "bin"
+                )
+                runtime.mkdir(parents=True)
+                python = runtime / "python"
+                python.write_bytes(b"python")
+                with patch("tool.tts_service.Path.home", return_value=Path(home)):
+                    command, _ = _build_start_command(
+                        engine,
+                        ("127.0.0.1", 9880),
+                    )
+            self.assertEqual(Path(command[0]), python.resolve())
 
     def test_ensure_running_launches_once_and_stop_only_owned_process(
         self,
@@ -189,7 +226,10 @@ class TTSServiceTests(unittest.TestCase):
     @staticmethod
     def _create_engine(root: Path) -> Path:
         (root / "runtime").mkdir(parents=True)
-        (root / "runtime" / "python.exe").write_bytes(b"runtime")
+        runtime = root / "runtime" / (
+            "python.exe" if os.name == "nt" else "python"
+        )
+        runtime.write_bytes(b"runtime")
         (root / "api_v2.py").write_text("# api", encoding="utf-8")
         config = root / "GPT_SoVITS" / "configs" / "tts_infer.yaml"
         config.parent.mkdir(parents=True)

--- a/tool/credentials.py
+++ b/tool/credentials.py
@@ -3,11 +3,17 @@ from __future__ import annotations
 import base64
 import ctypes
 import os
+import subprocess
+import sys
 from ctypes import wintypes
 
 
 class CredentialError(RuntimeError):
     pass
+
+
+KEYCHAIN_SERVICE = "AIpet-Murasame AutoDL TTS"
+KEYCHAIN_ACCOUNT = "AutoDL"
 
 
 class _DataBlob(ctypes.Structure):
@@ -47,13 +53,36 @@ def _windows_apis():
 
 
 def protect_secret(secret: str) -> str:
-    """Encrypt a secret for the current Windows user with DPAPI."""
+    """Store a secret with the current operating system's credential service."""
 
     if not secret:
         return ""
+    if sys.platform == "darwin":
+        try:
+            subprocess.run(
+                [
+                    "/usr/bin/security",
+                    "add-generic-password",
+                    "-U",
+                    "-a",
+                    KEYCHAIN_ACCOUNT,
+                    "-s",
+                    KEYCHAIN_SERVICE,
+                    "-w",
+                    secret,
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except (OSError, subprocess.CalledProcessError) as exc:
+            raise CredentialError(
+                "macOS could not save the AutoDL password in Keychain."
+            ) from exc
+        return f"keychain:{KEYCHAIN_ACCOUNT}"
     if os.name != "nt":
         raise CredentialError(
-            "AutoDL password storage is available only on Windows."
+            "Secure AutoDL password storage is unavailable on this system."
         )
 
     raw = secret.encode("utf-8")
@@ -85,13 +114,36 @@ def protect_secret(secret: str) -> str:
 
 
 def unprotect_secret(token: str) -> str:
-    """Decrypt a DPAPI token created for the current Windows user."""
+    """Read a secret from the current operating system's credential service."""
 
     if not token:
         return ""
+    if sys.platform == "darwin":
+        if token != f"keychain:{KEYCHAIN_ACCOUNT}":
+            raise CredentialError("The stored AutoDL password is invalid.")
+        try:
+            result = subprocess.run(
+                [
+                    "/usr/bin/security",
+                    "find-generic-password",
+                    "-a",
+                    KEYCHAIN_ACCOUNT,
+                    "-s",
+                    KEYCHAIN_SERVICE,
+                    "-w",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except (OSError, subprocess.CalledProcessError) as exc:
+            raise CredentialError(
+                "macOS could not read the AutoDL password from Keychain."
+            ) from exc
+        return result.stdout.rstrip("\n")
     if os.name != "nt":
         raise CredentialError(
-            "AutoDL password storage is available only on Windows."
+            "Secure AutoDL password storage is unavailable on this system."
         )
     try:
         encrypted = base64.b64decode(token, validate=True)

--- a/tool/macos_overlay.py
+++ b/tool/macos_overlay.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from PyQt5.QtCore import QTimer
+from PyQt5.QtWidgets import QApplication
+
+from tool.config import PROJECT_ROOT
+from tool.runtime_logging import get_logger
+
+
+logger = get_logger("macos-overlay")
+HEAD_PAT_COMMAND = "__murasame_head_pat__"
+
+
+class MacOSFullscreenOverlay:
+    """Bridge the Qt pet to a native panel in macOS fullscreen Spaces."""
+
+    def __init__(self, app: QApplication, pet) -> None:
+        self.pet = pet
+        self.process: subprocess.Popen[bytes] | None = None
+        self.fullscreen = False
+        self.command_mtime = 0
+        self.directory = pet.native_overlay_directory
+        self.state_path = self.directory / "fullscreen.state"
+        self.visibility_path = self.directory / "qt_visible.state"
+        self.command_path = self.directory / "command.txt"
+        self.timer = QTimer(app)
+        self.timer.setInterval(100)
+        self.timer.timeout.connect(self.sync)
+
+    def start(self) -> None:
+        if sys.platform != "darwin":
+            return
+        binary = PROJECT_ROOT / ".native_overlay" / "murasame_overlay"
+        portrait = self.directory / "portrait.png"
+        if not binary.is_file() or not portrait.is_file():
+            logger.warning("macOS 全屏兼容组件不可用，继续使用普通桌宠窗口")
+            return
+
+        self.directory.mkdir(parents=True, exist_ok=True)
+        self.command_path.write_text("", encoding="utf-8")
+        self._write_qt_visibility()
+        self.process = subprocess.Popen(
+            [
+                str(binary),
+                str(portrait),
+                str(self.directory / "text.txt"),
+                str(self.state_path),
+                str(self.visibility_path),
+                str(self.command_path),
+            ],
+            cwd=str(PROJECT_ROOT),
+        )
+        self.timer.start()
+        logger.info("macOS 原生全屏兼容组件已启动")
+
+    def sync(self) -> None:
+        if self.process is None or self.process.poll() is not None:
+            self.timer.stop()
+            return
+        self._write_qt_visibility()
+        self._consume_command()
+        try:
+            fullscreen = (
+                self.state_path.read_text(encoding="utf-8").strip() == "1"
+            )
+        except OSError:
+            fullscreen = False
+        if fullscreen == self.fullscreen:
+            return
+
+        self.fullscreen = fullscreen
+        if fullscreen:
+            self.pet.hide()
+            logger.info("已切换至 macOS 全屏兼容窗口")
+        else:
+            self.pet.show()
+            logger.info("已恢复 Qt 桌宠窗口")
+        self._write_qt_visibility()
+
+    def _consume_command(self) -> None:
+        try:
+            modified = self.command_path.stat().st_mtime_ns
+            if modified <= self.command_mtime:
+                return
+            self.command_mtime = modified
+            command = self.command_path.read_text(encoding="utf-8").strip()
+            if not command:
+                return
+            self.command_path.write_text("", encoding="utf-8")
+            if command == HEAD_PAT_COMMAND:
+                self.pet.start_thread("主人摸了摸你的头。", role="system")
+            else:
+                self.pet.start_thread(command, role="user")
+        except (OSError, UnicodeError):
+            pass
+
+    def _write_qt_visibility(self) -> None:
+        try:
+            self.visibility_path.write_text(
+                "1\n" if self.pet.isVisible() else "0\n",
+                encoding="utf-8",
+            )
+        except OSError:
+            pass
+
+    def stop(self) -> None:
+        self.timer.stop()
+        if self.process is not None and self.process.poll() is None:
+            self.process.terminate()
+            try:
+                self.process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+        self.process = None

--- a/tool/tts_service.py
+++ b/tool/tts_service.py
@@ -4,6 +4,7 @@ import atexit
 import ctypes
 import os
 import subprocess
+import sys
 import threading
 import time
 from pathlib import Path
@@ -600,8 +601,35 @@ def _build_start_command(
 
 
 def _locate_runtime_python(engine_root: Path) -> Path:
+    configured = os.environ.get("AIPET_GPT_SOVITS_PYTHON", "").strip()
+    if configured:
+        candidate = Path(configured).expanduser()
+        if candidate.is_file():
+            return candidate.resolve()
+        raise TTSServiceError(
+            "AIPET_GPT_SOVITS_PYTHON does not point to a Python executable."
+        )
+
     names = ("python.exe",) if os.name == "nt" else ("python", "python3")
-    for directory in (engine_root / "runtime", engine_root):
+    directories = [engine_root / "runtime"]
+    if sys.platform == "darwin":
+        directories.extend(
+            [
+                engine_root / ".venv" / "bin",
+                engine_root / "venv" / "bin",
+                (
+                    Path.home()
+                    / ".local"
+                    / "share"
+                    / "AIpet-Murasame"
+                    / "gpt-sovits"
+                    / "env"
+                    / "bin"
+                ),
+            ]
+        )
+    directories.append(engine_root)
+    for directory in directories:
         for name in names:
             candidate = directory / name
             if candidate.is_file():

--- a/tool/voice_trigger.py
+++ b/tool/voice_trigger.py
@@ -268,4 +268,116 @@ class CapslockVoiceTrigger:
         t.start()
 
 
-__all__ = ["CapslockVoiceTrigger"]
+class MacOSHotkeyVoiceTrigger(CapslockVoiceTrigger):
+    """macOS native Option+V hold-to-record trigger.
+
+    This uses a listen-only Quartz event tap instead of pynput.  In particular,
+    it avoids the Caps Lock/input-source path that can crash macOS's input
+    method service.
+    """
+
+    _KEYCODE_V = 9
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._hotkey_pressed = False
+        self._event_tap = None
+        self._run_loop = None
+        self._event_thread: Optional[threading.Thread] = None
+        self._event_callback = None
+
+    def start(self) -> None:
+        if self._event_thread is not None:
+            return
+        try:
+            import Quartz
+        except ImportError as exc:
+            raise RuntimeError("macOS 录音快捷键需要 pyobjc-framework-Quartz") from exc
+
+        mask = Quartz.CGEventMaskBit(Quartz.kCGEventKeyDown) | Quartz.CGEventMaskBit(
+            Quartz.kCGEventKeyUp
+        )
+
+        def callback(proxy, event_type, event, refcon):
+            keycode = Quartz.CGEventGetIntegerValueField(
+                event, Quartz.kCGKeyboardEventKeycode
+            )
+            flags = Quartz.CGEventGetFlags(event)
+            modifiers = Quartz.kCGEventFlagMaskAlternate
+            if keycode == self._KEYCODE_V:
+                if event_type == Quartz.kCGEventKeyDown:
+                    if flags & modifiers == modifiers:
+                        self._on_hotkey_press()
+                elif event_type == Quartz.kCGEventKeyUp:
+                    self._on_hotkey_release()
+            return event
+
+        self._event_callback = callback
+        self._event_tap = Quartz.CGEventTapCreate(
+            Quartz.kCGSessionEventTap,
+            Quartz.kCGHeadInsertEventTap,
+            Quartz.kCGEventTapOptionListenOnly,
+            mask,
+            callback,
+            None,
+        )
+        if self._event_tap is None:
+            self._event_callback = None
+            raise RuntimeError(
+                "无法创建 macOS 全局快捷键监听，请在系统设置中允许本程序使用辅助功能"
+            )
+
+        def run_events():
+            self._run_loop = Quartz.CFRunLoopGetCurrent()
+            source = Quartz.CFMachPortCreateRunLoopSource(None, self._event_tap, 0)
+            Quartz.CFRunLoopAddSource(
+                self._run_loop, source, Quartz.kCFRunLoopCommonModes
+            )
+            Quartz.CGEventTapEnable(self._event_tap, True)
+            logger.info("macOS Option+V 语音触发已启动")
+            Quartz.CFRunLoopRun()
+
+        self._event_thread = threading.Thread(target=run_events, daemon=True)
+        self._event_thread.start()
+
+    def stop(self) -> None:
+        super().stop()
+        self._hotkey_pressed = False
+        if self._run_loop is not None:
+            try:
+                import Quartz
+
+                Quartz.CFRunLoopStop(self._run_loop)
+            except Exception:
+                logger.exception("停止 macOS 快捷键监听失败")
+        thread = self._event_thread
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=1.0)
+        self._event_thread = None
+        self._run_loop = None
+        self._event_tap = None
+        self._event_callback = None
+
+    def _on_hotkey_press(self) -> None:
+        if self._hotkey_pressed:
+            return
+        self._hotkey_pressed = True
+        self._caps_pressed = True
+        self._hold_timer = threading.Timer(self.hold_seconds, self._maybe_start_record)
+        self._hold_timer.daemon = True
+        self._hold_timer.start()
+
+    def _on_hotkey_release(self) -> None:
+        if not self._hotkey_pressed:
+            return
+        self._hotkey_pressed = False
+        self._caps_pressed = False
+        if self._hold_timer is not None:
+            self._hold_timer.cancel()
+            self._hold_timer = None
+        if self._recording:
+            self._recording = False
+            self._handle_record_done()
+
+
+__all__ = ["CapslockVoiceTrigger", "MacOSHotkeyVoiceTrigger"]

--- a/tool/windowing.py
+++ b/tool/windowing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ctypes
+import ctypes.util
 import os
 from ctypes import wintypes
 from functools import lru_cache
@@ -32,9 +33,60 @@ def ensure_window_topmost(window_id: int) -> bool:
     return True
 
 
+def get_system_idle_seconds() -> float:
+    if os.name == "nt":
+        return _windows_idle_seconds()
+    if sys_platform_is_macos():
+        return _macos_idle_seconds()
+    return 0.0
+
+
+def sys_platform_is_macos() -> bool:
+    return os.uname().sysname == "Darwin" if hasattr(os, "uname") else False
+
+
+def _windows_idle_seconds() -> float:
+    class LastInputInfo(ctypes.Structure):
+        _fields_ = [
+            ("cbSize", wintypes.UINT),
+            ("dwTime", wintypes.DWORD),
+        ]
+
+    info = LastInputInfo()
+    info.cbSize = ctypes.sizeof(LastInputInfo)
+    user32 = _windows_user32()
+    if not user32.GetLastInputInfo(ctypes.byref(info)):
+        return 0.0
+    milliseconds = (
+        ctypes.windll.kernel32.GetTickCount() - info.dwTime
+    ) & 0xFFFFFFFF
+    return milliseconds / 1000.0
+
+
+@lru_cache(maxsize=1)
+def _macos_application_services():
+    path = ctypes.util.find_library("ApplicationServices")
+    if not path:
+        return None
+    library = ctypes.CDLL(path)
+    function = library.CGEventSourceSecondsSinceLastEventType
+    function.argtypes = [ctypes.c_uint32, ctypes.c_uint32]
+    function.restype = ctypes.c_double
+    return function
+
+
+def _macos_idle_seconds() -> float:
+    function = _macos_application_services()
+    if function is None:
+        return 0.0
+    return max(0.0, float(function(0, 0xFFFFFFFF)))
+
+
 @lru_cache(maxsize=1)
 def _windows_user32():
     user32 = ctypes.WinDLL("user32", use_last_error=True)
+    user32.GetLastInputInfo.argtypes = [ctypes.c_void_p]
+    user32.GetLastInputInfo.restype = wintypes.BOOL
     user32.SetWindowPos.argtypes = [
         wintypes.HWND,
         wintypes.HWND,

--- a/ui/settings_dialog.py
+++ b/ui/settings_dialog.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+import subprocess
 from pathlib import Path
 
 from pydantic import ValidationError
@@ -54,6 +56,7 @@ from tool.config import (
     TTSSettings,
     VisionSettings,
     get_user_data_dir,
+    PROJECT_ROOT,
     load_personality,
 )
 from tool.credentials import CredentialError, protect_secret
@@ -62,6 +65,8 @@ from tool.tts_assets import (
     TTSAssetState,
     configure_local_tts_weights,
     locate_tts_assets,
+    managed_gpt_sovits_dir,
+    managed_tts_model_dir,
     tts_service_is_reachable,
 )
 from tool.tts_service import (
@@ -169,7 +174,7 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "tts_autodl_remote_command": "Remote TTS start command",
         "tts_autodl_reference_root": "Remote reference voice directory",
         "tts_autodl_password_placeholder": (
-            "Leave blank to keep the password saved with Windows encryption"
+            "Leave blank to keep the password in the system credential store"
         ),
         "browse": "Browse…",
         "tts_disabled": (
@@ -181,7 +186,7 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
             "command, and remote reference voice directory."
         ),
         "tts_password_store_failed": (
-            "Windows could not save the AutoDL password securely: {message}"
+            "The system could not save the AutoDL password securely: {message}"
         ),
         "tts_checking": "Checking GPT-SoVITS components…",
         "tts_ready_online": "Voice model is ready and the TTS service is online.",
@@ -229,7 +234,17 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
             "additional free space while extracting. The assets are intended "
             "for non-commercial, educational use."
         ),
+        "tts_download_consent_body_macos": (
+            "Download the Murasame character weights and six reference voices "
+            "(about 231 MB) from ModelScope? On macOS, install GPT-SoVITS "
+            "separately, then select its directory in Settings."
+        ),
         "tts_download": "Download voice model",
+        "tts_macos_setup": "Install GPT-SoVITS for macOS",
+        "tts_macos_setup_opened": (
+            "The macOS GPT-SoVITS installer is running in Terminal. "
+            "After it finishes, download the Murasame voice model here."
+        ),
         "tts_preparing": "Preparing the TTS download: {detail}",
         "tts_downloading": "Downloading the Murasame voice model: {detail}",
         "tts_checking_files": "Checking downloaded files: {detail}",
@@ -241,6 +256,7 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "download_files": "files",
         "download_steps": "steps",
         "stt_enabled": "Hold Caps Lock for speech input",
+        "stt_enabled_macos": "Hold Option + V for speech input",
         "whisper_model": "Whisper model or repository ID",
         "whisper_model_dir": "Whisper model download directory",
         "stt_input_device": "Recording device",
@@ -470,7 +486,7 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "tts_autodl_remote_command": "远程 TTS 启动命令",
         "tts_autodl_reference_root": "服务器参考音频目录",
         "tts_autodl_password_placeholder": (
-            "留空则继续使用 Windows 当前用户加密保存的密码"
+            "留空则继续使用系统凭据存储中保存的密码"
         ),
         "browse": "浏览…",
         "tts_disabled": "启用 TTS 后，将检查引擎、角色模型、参考音频和服务。",
@@ -479,7 +495,7 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
             "请填写 AutoDL SSH 登录命令、密码、远程启动命令和服务器参考音频目录。"
         ),
         "tts_password_store_failed": (
-            "Windows 无法安全保存 AutoDL 密码：{message}"
+            "系统无法安全保存 AutoDL 密码：{message}"
         ),
         "tts_checking": "正在检查 GPT-SoVITS 组件……",
         "tts_ready_online": "角色语音模型完整，TTS 服务在线。",
@@ -518,7 +534,17 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
             "完整引擎，同时下载角色权重和参考音频？下载量约 8～9 GB，"
             "解压时还需要额外可用空间。这些资源仅用于非商业和学习用途。"
         ),
+        "tts_download_consent_body_macos": (
+            "是否从 ModelScope 下载丛雨角色权重及六组参考音频（约 231 MB）？"
+            "macOS 不下载 Windows 整合引擎；请另行安装 GPT-SoVITS，"
+            "再在设置中选择其目录。"
+        ),
         "tts_download": "下载角色语音模型",
+        "tts_macos_setup": "安装 macOS GPT-SoVITS",
+        "tts_macos_setup_opened": (
+            "macOS GPT-SoVITS 安装程序已在终端运行。安装完成后，"
+            "请在这里下载丛雨角色语音模型。"
+        ),
         "tts_preparing": "正在准备 TTS 下载：{detail}",
         "tts_downloading": "正在下载丛雨语音模型：{detail}",
         "tts_checking_files": "正在校验已下载文件：{detail}",
@@ -530,6 +556,7 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "download_files": "个文件",
         "download_steps": "个步骤",
         "stt_enabled": "长按 Caps Lock 进行语音输入",
+        "stt_enabled_macos": "长按 Option + V 进行语音输入",
         "whisper_model": "Whisper 模型或仓库 ID",
         "whisper_model_dir": "Whisper 模型下载目录",
         "stt_input_device": "录音设备",
@@ -1210,6 +1237,10 @@ class SettingsDialog(QDialog):
         self.tts_download_button.clicked.connect(
             self._request_tts_download
         )
+        self.tts_macos_setup_button = QPushButton()
+        self.tts_macos_setup_button.clicked.connect(
+            self._setup_macos_tts
+        )
         self.tts_service_button = QPushButton()
         self.tts_service_button.setEnabled(False)
         self.tts_service_button.clicked.connect(
@@ -1282,6 +1313,7 @@ class SettingsDialog(QDialog):
             self.tts_autodl_reference_root,
         )
         tts_form.addRow(self.tts_status)
+        tts_form.addRow(self.tts_macos_setup_button)
         tts_form.addRow(self.tts_service_button)
         tts_form.addRow(self.tts_progress)
         tts_form.addRow(self.tts_extract_progress)
@@ -1839,8 +1871,13 @@ class SettingsDialog(QDialog):
         self.tts_engine_browse.setText(self._text("browse"))
         self.tts_model_browse.setText(self._text("browse"))
         self.tts_download_button.setText(self._text("tts_download"))
+        self.tts_macos_setup_button.setText(self._text("tts_macos_setup"))
         self._render_tts_service_button()
-        self.stt_enabled.setText(self._text("stt_enabled"))
+        self.stt_enabled.setText(
+            self._text(
+                "stt_enabled_macos" if sys.platform == "darwin" else "stt_enabled"
+            )
+        )
         self._retranslate_audio_input_devices()
         self._set_combo_item_text(
             self.stt_device,
@@ -2198,6 +2235,10 @@ class SettingsDialog(QDialog):
         self._set_form_rows_visible(local_keys, not autodl)
         self._set_form_rows_visible(autodl_keys, autodl)
         self.tts_download_button.setVisible(not autodl)
+        self.tts_macos_setup_button.setVisible(
+            sys.platform == "darwin" and not autodl
+        )
+        self.tts_macos_setup_button.setEnabled(local_enabled)
         if autodl:
             self.tts_progress.hide()
             self.tts_extract_progress.hide()
@@ -2341,6 +2382,7 @@ class SettingsDialog(QDialog):
                 self._set_tts_status("tts_ready_offline")
             if (
                 self._tts_engine_download_needed
+                and sys.platform != "darwin"
                 and not self._tts_download_prompted
             ):
                 self._tts_download_prompted = True
@@ -2430,6 +2472,28 @@ class SettingsDialog(QDialog):
         if key is not None:
             self._set_tts_status(key)
 
+    def _setup_macos_tts(self) -> None:
+        if sys.platform != "darwin":
+            return
+        script = PROJECT_ROOT / "install_macos_tts.command"
+        if not script.is_file():
+            self._set_tts_status(
+                "tts_service_failed",
+                message="install_macos_tts.command was not found.",
+            )
+            return
+        self.tts_engine_root.setText(str(managed_gpt_sovits_dir()))
+        self.tts_model_dir.setText(str(managed_tts_model_dir()))
+        try:
+            subprocess.Popen(
+                ["open", "-a", "Terminal", str(script)],
+                cwd=str(PROJECT_ROOT),
+            )
+        except OSError as exc:
+            self._set_tts_status("tts_service_failed", message=str(exc))
+            return
+        self._set_tts_status("tts_macos_setup_opened")
+
     def _on_tts_service_succeeded(self, action: str) -> None:
         self._set_tts_status(
             "tts_service_stopped"
@@ -2466,8 +2530,11 @@ class SettingsDialog(QDialog):
         )
         if model_destination is None:
             return
+        include_engine = (
+            self._tts_engine_download_needed and sys.platform != "darwin"
+        )
         engine_destination = None
-        if self._tts_engine_download_needed:
+        if include_engine:
             engine_destination = self._require_download_directory(
                 self.tts_engine_root,
                 "tts_engine_path_required",
@@ -2478,9 +2545,16 @@ class SettingsDialog(QDialog):
             self,
             self._text("tts_download_consent_title"),
             self._text(
-                "tts_download_consent_body_with_engine"
-                if self._tts_engine_download_needed
-                else "tts_download_consent_body"
+                "tts_download_consent_body_macos"
+                if (
+                    sys.platform == "darwin"
+                    and self._tts_engine_download_needed
+                )
+                else (
+                    "tts_download_consent_body_with_engine"
+                    if include_engine
+                    else "tts_download_consent_body"
+                )
             ),
             QMessageBox.Yes | QMessageBox.No,
             QMessageBox.Yes,
@@ -2489,7 +2563,7 @@ class SettingsDialog(QDialog):
             return
         self.download_manager.start_tts(
             model_destination,
-            include_engine=self._tts_engine_download_needed,
+            include_engine=include_engine,
             engine_destination=engine_destination,
         )
         self._set_tts_path_controls(downloading=True)

--- a/ui/settings_dialog.py
+++ b/ui/settings_dialog.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 import sys
-import subprocess
 from pathlib import Path
 
 from pydantic import ValidationError
-from PyQt5.QtCore import Qt, QThread, QTimer, pyqtSignal
+from PyQt5.QtCore import QThread, QTimer, pyqtSignal
 from PyQt5.QtWidgets import (
     QApplication,
     QCheckBox,
@@ -28,7 +27,6 @@ from PyQt5.QtWidgets import (
     QSpinBox,
     QStackedWidget,
     QTabWidget,
-    QToolButton,
     QVBoxLayout,
     QWidget,
 )
@@ -41,10 +39,10 @@ from classes.download_manager import (
 )
 from tool.audio_devices import (
     decode_audio_input_device,
-    refresh_audio_input_devices,
+    default_audio_input_device,
+    list_audio_input_devices,
 )
 from tool.backends import create_backend, create_vision_backend
-from tool.cache import clear_runtime_cache
 from tool.config import (
     APISettings,
     AppSettings,
@@ -56,17 +54,14 @@ from tool.config import (
     TTSSettings,
     VisionSettings,
     get_user_data_dir,
-    PROJECT_ROOT,
     load_personality,
 )
-from tool.credentials import CredentialError, protect_secret
+from tool.network import is_loopback_url
 from tool.runtime_logging import get_logger
 from tool.tts_assets import (
     TTSAssetState,
     configure_local_tts_weights,
     locate_tts_assets,
-    managed_gpt_sovits_dir,
-    managed_tts_model_dir,
     tts_service_is_reachable,
 )
 from tool.tts_service import (
@@ -91,7 +86,6 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "tab_character": "Character",
         "tab_automation": "Automation",
         "tab_display": "Display",
-        "tab_other": "Other",
         "backend_group": "Backend mode",
         "mode": "Mode",
         "mode_ollama": "Ollama (local service)",
@@ -162,32 +156,15 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "tts_group": "Text-to-speech (GPT-SoVITS)",
         "whisper_group": "Speech input (Whisper)",
         "tts_enabled": "Use GPT-SoVITS-compatible TTS",
-        "tts_backend": "TTS location",
-        "tts_backend_local": "Local computer",
-        "tts_backend_autodl": "AutoDL cloud",
         "tts_endpoint": "TTS endpoint",
         "tts_timeout": "TTS timeout",
         "tts_engine_root": "GPT-SoVITS download/install directory",
         "tts_model_dir": "Voice model download directory (includes references)",
-        "tts_autodl_ssh_command": "AutoDL SSH login command",
-        "tts_autodl_password": "AutoDL SSH password",
-        "tts_autodl_remote_command": "Remote TTS start command",
-        "tts_autodl_reference_root": "Remote reference voice directory",
-        "tts_autodl_password_placeholder": (
-            "Leave blank to keep the password in the system credential store"
-        ),
         "browse": "Browse…",
         "tts_disabled": (
             "Enable TTS to check the engine, voice model, references, and service."
         ),
         "tts_invalid": "Enter a valid TTS endpoint before checking it.",
-        "tts_autodl_missing": (
-            "Enter the AutoDL SSH login command, password, remote start "
-            "command, and remote reference voice directory."
-        ),
-        "tts_password_store_failed": (
-            "The system could not save the AutoDL password securely: {message}"
-        ),
         "tts_checking": "Checking GPT-SoVITS components…",
         "tts_ready_online": "Voice model is ready and the TTS service is online.",
         "tts_ready_offline": (
@@ -198,9 +175,6 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "tts_service_online": "TTS service online",
         "tts_service_locating": "Locating the GPT-SoVITS runtime…",
         "tts_service_starting": "Starting the GPT-SoVITS process…",
-        "tts_service_connecting_ssh": "Connecting to AutoDL over SSH…",
-        "tts_service_starting_remote": "Running the AutoDL TTS start command…",
-        "tts_service_starting_tunnel": "Opening the local SSH tunnel…",
         "tts_service_waiting": "Waiting for the TTS API to become ready…",
         "tts_service_waiting_existing": (
             "Another request is starting the TTS service; waiting…"
@@ -234,17 +208,7 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
             "additional free space while extracting. The assets are intended "
             "for non-commercial, educational use."
         ),
-        "tts_download_consent_body_macos": (
-            "Download the Murasame character weights and six reference voices "
-            "(about 231 MB) from ModelScope? On macOS, install GPT-SoVITS "
-            "separately, then select its directory in Settings."
-        ),
         "tts_download": "Download voice model",
-        "tts_macos_setup": "Install GPT-SoVITS for macOS",
-        "tts_macos_setup_opened": (
-            "The macOS GPT-SoVITS installer is running in Terminal. "
-            "After it finishes, download the Murasame voice model here."
-        ),
         "tts_preparing": "Preparing the TTS download: {detail}",
         "tts_downloading": "Downloading the Murasame voice model: {detail}",
         "tts_checking_files": "Checking downloaded files: {detail}",
@@ -256,7 +220,6 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "download_files": "files",
         "download_steps": "steps",
         "stt_enabled": "Hold Caps Lock for speech input",
-        "stt_enabled_macos": "Hold Option + V for speech input",
         "whisper_model": "Whisper model or repository ID",
         "whisper_model_dir": "Whisper model download directory",
         "stt_input_device": "Recording device",
@@ -264,11 +227,6 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "stt_input_default_unknown": "System default input",
         "stt_input_unavailable": "Unavailable: {device}",
         "stt_device": "STT device",
-        "stt_device_auto": "Auto",
-        "stt_device_cuda": (
-            "CUDA (requires the AIpet-with-cuda build; unavailable otherwise)"
-        ),
-        "stt_device_cpu": "CPU",
         "whisper_download": "Download model",
         "whisper_disabled": (
             "Enable speech input to check the selected download directory."
@@ -302,21 +260,6 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         ),
         "download_path_invalid": "The selected directory cannot be used: {message}",
         "automation_group": "Idle behavior and memory",
-        "settings_help": "Explain these settings",
-        "automation_help_title": "Idle behavior and memory",
-        "automation_help_body": (
-            "Thinking reminder: after this much inactivity, the character may "
-            "gently check whether you are still there. It triggers at most "
-            "once per idle period.\n\n"
-            "Away reminder: after the longer inactivity threshold, the "
-            "character treats you as away. When you return, she may welcome "
-            "you back. This value must be greater than the thinking reminder."
-            "\n\n"
-            "Conversation memory: the maximum number of recent messages kept "
-            "and supplied as conversation context.\n\n"
-            "Do not disturb: disables proactive idle and return messages; "
-            "manual conversation still works."
-        ),
         "do_not_disturb": "Do not disturb",
         "clear_history": "Clear conversation history…",
         "clear_history_confirm_title": "Clear conversation history?",
@@ -328,33 +271,7 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "history_unavailable_first_run": (
             "Conversation history is not available during initial setup."
         ),
-        "data_group": "Data management",
-        "conversation_history_data": "Conversation history",
-        "runtime_cache_data": "Temporary screenshots, speech, and recordings",
-        "clear_cache": "Clear cache…",
-        "clear_cache_confirm_title": "Clear cached files?",
-        "clear_cache_confirm_body": (
-            "This removes temporary screenshots, generated speech, and "
-            "recordings. Settings, conversation history, models, and logs "
-            "are not affected."
-        ),
-        "cache_cleared": "Cleared {files} cached files, freeing {size}.",
-        "cache_empty": "The cache is already empty.",
-        "cache_clear_partial": (
-            "Cleared {files} cached files ({size}), but {failed} files or "
-            "folders are still in use or could not be removed."
-        ),
         "display_group": "Screen and portrait",
-        "display_help_title": "Screen and portrait",
-        "display_help_body": (
-            "Screen index: the zero-based position in Windows' current screen "
-            "list. If the index is unavailable, the primary screen is used."
-            "\n\n"
-            "Portrait height ratio: the character's target height as a share "
-            "of the selected screen's available height.\n\n"
-            "Live diagnostic console: opens a live log window for diagnosing "
-            "model, TTS, recording, and other runtime problems."
-        ),
         "screen_index": "Screen index",
         "portrait_ratio": "Portrait height ratio",
         "show_log_console": "Open live diagnostic console",
@@ -408,7 +325,6 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "tab_character": "角色",
         "tab_automation": "自动行为",
         "tab_display": "显示",
-        "tab_other": "其他",
         "backend_group": "后端模式",
         "mode": "模式",
         "mode_ollama": "Ollama（本地服务）",
@@ -474,29 +390,13 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "tts_group": "语音合成（GPT-SoVITS）",
         "whisper_group": "语音输入（Whisper）",
         "tts_enabled": "使用 GPT-SoVITS 兼容 TTS",
-        "tts_backend": "TTS 位置",
-        "tts_backend_local": "本机",
-        "tts_backend_autodl": "AutoDL 云端",
         "tts_endpoint": "TTS 地址",
         "tts_timeout": "TTS 超时",
         "tts_engine_root": "GPT-SoVITS 下载及安装目录",
         "tts_model_dir": "角色语音模型下载目录（含参考音频）",
-        "tts_autodl_ssh_command": "AutoDL SSH 登录命令",
-        "tts_autodl_password": "AutoDL SSH 密码",
-        "tts_autodl_remote_command": "远程 TTS 启动命令",
-        "tts_autodl_reference_root": "服务器参考音频目录",
-        "tts_autodl_password_placeholder": (
-            "留空则继续使用系统凭据存储中保存的密码"
-        ),
         "browse": "浏览…",
         "tts_disabled": "启用 TTS 后，将检查引擎、角色模型、参考音频和服务。",
         "tts_invalid": "请先填写有效的 TTS 地址。",
-        "tts_autodl_missing": (
-            "请填写 AutoDL SSH 登录命令、密码、远程启动命令和服务器参考音频目录。"
-        ),
-        "tts_password_store_failed": (
-            "系统无法安全保存 AutoDL 密码：{message}"
-        ),
         "tts_checking": "正在检查 GPT-SoVITS 组件……",
         "tts_ready_online": "角色语音模型完整，TTS 服务在线。",
         "tts_ready_offline": "角色语音模型完整，但 TTS 服务尚未运行。",
@@ -505,9 +405,6 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "tts_service_online": "TTS 服务在线",
         "tts_service_locating": "正在定位 GPT-SoVITS 运行环境……",
         "tts_service_starting": "正在启动 GPT-SoVITS 进程……",
-        "tts_service_connecting_ssh": "正在通过 SSH 连接 AutoDL……",
-        "tts_service_starting_remote": "正在执行 AutoDL TTS 启动命令……",
-        "tts_service_starting_tunnel": "正在建立本机 SSH 隧道……",
         "tts_service_waiting": "正在等待 TTS API 就绪……",
         "tts_service_waiting_existing": "已有请求正在启动 TTS 服务，正在等待……",
         "tts_service_loading_weights": "正在加载角色语音权重……",
@@ -534,17 +431,7 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
             "完整引擎，同时下载角色权重和参考音频？下载量约 8～9 GB，"
             "解压时还需要额外可用空间。这些资源仅用于非商业和学习用途。"
         ),
-        "tts_download_consent_body_macos": (
-            "是否从 ModelScope 下载丛雨角色权重及六组参考音频（约 231 MB）？"
-            "macOS 不下载 Windows 整合引擎；请另行安装 GPT-SoVITS，"
-            "再在设置中选择其目录。"
-        ),
         "tts_download": "下载角色语音模型",
-        "tts_macos_setup": "安装 macOS GPT-SoVITS",
-        "tts_macos_setup_opened": (
-            "macOS GPT-SoVITS 安装程序已在终端运行。安装完成后，"
-            "请在这里下载丛雨角色语音模型。"
-        ),
         "tts_preparing": "正在准备 TTS 下载：{detail}",
         "tts_downloading": "正在下载丛雨语音模型：{detail}",
         "tts_checking_files": "正在校验已下载文件：{detail}",
@@ -556,7 +443,6 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "download_files": "个文件",
         "download_steps": "个步骤",
         "stt_enabled": "长按 Caps Lock 进行语音输入",
-        "stt_enabled_macos": "长按 Option + V 进行语音输入",
         "whisper_model": "Whisper 模型或仓库 ID",
         "whisper_model_dir": "Whisper 模型下载目录",
         "stt_input_device": "录音设备",
@@ -564,11 +450,6 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "stt_input_default_unknown": "系统默认输入设备",
         "stt_input_unavailable": "当前不可用：{device}",
         "stt_device": "语音识别设备",
-        "stt_device_auto": "自动",
-        "stt_device_cuda": (
-            "CUDA（请使用 AIpet-with-cuda 版本，否则无法使用）"
-        ),
-        "stt_device_cpu": "CPU",
         "whisper_download": "下载模型",
         "whisper_disabled": "启用语音输入后，将检查填写的模型下载目录。",
         "whisper_checking": "正在检查填写的模型目录……",
@@ -589,16 +470,6 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "whisper_path_required": "请先选择 Whisper 模型下载目录。",
         "download_path_invalid": "无法使用所选目录：{message}",
         "automation_group": "空闲行为与记忆",
-        "settings_help": "解释这些设置",
-        "automation_help_title": "空闲行为与记忆说明",
-        "automation_help_body": (
-            "思考提醒：持续无操作达到该时间后，角色可能会温和地询问你是否还在。"
-            "每段空闲期间最多触发一次。\n\n"
-            "离开提醒：持续无操作达到更长的时间后，角色会认为你暂时离开；"
-            "检测到你回来后，可能会欢迎你。该时间必须大于思考提醒。\n\n"
-            "对话记忆：最多保留并作为对话上下文发送的最近消息数量。\n\n"
-            "勿扰模式：停止主动的空闲提醒和回来问候，但手动对话仍可正常使用。"
-        ),
         "do_not_disturb": "勿扰模式",
         "clear_history": "清除历史对话…",
         "clear_history_confirm_title": "确定清除历史对话？",
@@ -608,30 +479,7 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         ),
         "history_cleared": "历史对话已清除。",
         "history_unavailable_first_run": "首次设置时没有可清除的历史对话。",
-        "data_group": "数据管理",
-        "conversation_history_data": "历史对话",
-        "runtime_cache_data": "临时截图、合成语音与录音",
-        "clear_cache": "清除缓存…",
-        "clear_cache_confirm_title": "确定清除缓存文件？",
-        "clear_cache_confirm_body": (
-            "这会删除临时截图、合成语音和录音。"
-            "设置、历史对话、模型与日志不会受到影响。"
-        ),
-        "cache_cleared": "已清除 {files} 个缓存文件，释放 {size}。",
-        "cache_empty": "缓存已经是空的。",
-        "cache_clear_partial": (
-            "已清除 {files} 个缓存文件（{size}），但仍有 {failed} 个"
-            "正在使用或无法删除的文件或文件夹。"
-        ),
         "display_group": "屏幕与立绘",
-        "display_help_title": "屏幕与立绘说明",
-        "display_help_body": (
-            "屏幕编号：当前 Windows 屏幕列表中从 0 开始的序号。"
-            "序号不可用时会回退到主屏幕。\n\n"
-            "立绘高度比例：角色立绘相对于所选屏幕可用高度的目标比例。\n\n"
-            "实时日志命令行：打开实时日志窗口，用于排查模型、TTS、录音及"
-            "其他运行问题。"
-        ),
         "screen_index": "屏幕编号",
         "portrait_ratio": "立绘高度比例",
         "show_log_console": "打开实时日志命令行",
@@ -751,13 +599,11 @@ class TTSServiceWorker(QThread):
         self,
         settings: TTSSettings,
         action: str,
-        password: str = "",
         parent=None,
     ):
         super().__init__(parent)
         self.settings = settings.model_copy(deep=True)
         self.action = action
-        self.password = password
 
     def run(self) -> None:
         manager = get_tts_service_manager()
@@ -771,30 +617,21 @@ class TTSServiceWorker(QThread):
                 configured_engine_root=self.settings.engine_root,
                 configured_model_dir=self.settings.model_dir,
             )
-            if not self.settings.uses_autodl() and not state.model_ready:
+            if not state.model_ready:
                 raise TTSServiceError(
                     "The Murasame voice weights are incomplete."
-                )
-            if (
-                not self.settings.uses_autodl()
-                and not state.reference_voices_ready
-            ):
-                raise TTSServiceError(
-                    "The Murasame reference voices are incomplete."
                 )
             manager.ensure_running(
                 self.settings,
                 state=state,
                 progress=self.stage_changed.emit,
-                password=self.password,
             )
-            if not self.settings.uses_autodl():
-                self.stage_changed.emit("loading_weights")
-                configure_local_tts_weights(
-                    self.settings.base_url,
-                    state,
-                    self.settings.timeout_seconds,
-                )
+            self.stage_changed.emit("loading_weights")
+            configure_local_tts_weights(
+                self.settings.base_url,
+                state,
+                self.settings.timeout_seconds,
+            )
             self.succeeded.emit("started")
         except Exception as exc:
             self.failed.emit(str(exc))
@@ -814,7 +651,6 @@ class SettingsDialog(QDialog):
         parent=None,
     ):
         super().__init__(parent)
-        self.setWindowFlag(Qt.WindowContextHelpButtonHint, False)
         self._original = settings.model_copy(deep=True)
         self._first_run = first_run
         self._model_worker: ModelListWorker | None = None
@@ -836,8 +672,6 @@ class SettingsDialog(QDialog):
             QApplication.instance()
         )
         self._form_labels: dict[str, list[QLabel]] = {}
-        self._form_fields: dict[str, list[QWidget]] = {}
-        self._audio_device_signature: tuple[object, ...] | None = None
         self._status_key: str | None = None
         self._status_values: dict[str, object] = {}
         self._whisper_status_key = "whisper_disabled"
@@ -863,7 +697,6 @@ class SettingsDialog(QDialog):
         self.tabs.addTab(self._build_character_tab(), "")
         self.tabs.addTab(self._build_automation_tab(), "")
         self.tabs.addTab(self._build_display_tab(), "")
-        self.tabs.addTab(self._build_other_tab(), "")
         root.addWidget(self.tabs, 1)
 
         self.status_label = QLabel()
@@ -877,11 +710,6 @@ class SettingsDialog(QDialog):
         self.buttons.rejected.connect(self.reject)
         root.addWidget(self.buttons)
 
-        self._audio_device_refresh_timer = QTimer(self)
-        self._audio_device_refresh_timer.setInterval(2_000)
-        self._audio_device_refresh_timer.timeout.connect(
-            self._refresh_audio_input_devices
-        )
         self._load_values(settings)
         self.language_combo.currentIndexChanged.connect(
             self._on_language_changed
@@ -893,24 +721,9 @@ class SettingsDialog(QDialog):
         )
         self.vision_enabled.toggled.connect(self._update_vision_state)
         self.tts_enabled.toggled.connect(self._update_tts_state)
-        self.tts_backend.currentIndexChanged.connect(
-            self._on_tts_backend_changed
-        )
         self.tts_url.editingFinished.connect(self._update_tts_state)
         self.tts_engine_root.editingFinished.connect(self._update_tts_state)
         self.tts_model_dir.editingFinished.connect(self._update_tts_state)
-        self.tts_autodl_ssh_command.editingFinished.connect(
-            self._update_tts_state
-        )
-        self.tts_autodl_password.editingFinished.connect(
-            self._update_tts_state
-        )
-        self.tts_autodl_remote_command.editingFinished.connect(
-            self._update_tts_state
-        )
-        self.tts_autodl_reference_root.editingFinished.connect(
-            self._update_tts_state
-        )
         self.download_manager.changed.connect(self._on_download_changed)
         self._update_backend_visibility()
         self._retranslate_ui()
@@ -920,16 +733,10 @@ class SettingsDialog(QDialog):
 
     def showEvent(self, event) -> None:
         super().showEvent(event)
-        self._refresh_audio_input_devices()
-        self._audio_device_refresh_timer.start()
         if self._auto_models_requested:
             return
         self._auto_models_requested = True
         QTimer.singleShot(0, self._auto_fetch_models)
-
-    def hideEvent(self, event) -> None:
-        self._audio_device_refresh_timer.stop()
-        super().hideEvent(event)
 
     def _add_row(
         self,
@@ -941,49 +748,6 @@ class SettingsDialog(QDialog):
         label.setWordWrap(True)
         form.addRow(label, field)
         self._form_labels.setdefault(key, []).append(label)
-        self._form_fields.setdefault(key, []).append(field)
-
-    def _set_form_labels_enabled(
-        self,
-        keys: tuple[str, ...],
-        enabled: bool,
-    ) -> None:
-        for key in keys:
-            for label in self._form_labels.get(key, ()):
-                label.setEnabled(enabled)
-
-    def _set_form_rows_visible(
-        self,
-        keys: tuple[str, ...],
-        visible: bool,
-    ) -> None:
-        for key in keys:
-            for label in self._form_labels.get(key, ()):
-                label.setVisible(visible)
-            for field in self._form_fields.get(key, ()):
-                field.setVisible(visible)
-
-    def _help_button(self, title_key: str, body_key: str) -> QToolButton:
-        button = QToolButton()
-        button.setText("?")
-        button.setFixedSize(24, 24)
-        button.clicked.connect(
-            lambda: QMessageBox.information(
-                self,
-                self._text(title_key),
-                self._text(body_key),
-            )
-        )
-        return button
-
-    @staticmethod
-    def _right_aligned_widget(widget: QWidget) -> QWidget:
-        container = QWidget()
-        layout = QHBoxLayout(container)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addStretch(1)
-        layout.addWidget(widget)
-        return container
 
     def _build_models_tab(self) -> QWidget:
         page = QWidget()
@@ -1209,9 +973,6 @@ class SettingsDialog(QDialog):
         self.tts_group = QGroupBox()
         tts_form = QFormLayout(self.tts_group)
         self.tts_enabled = QCheckBox()
-        self.tts_backend = QComboBox()
-        self.tts_backend.addItem("", "local")
-        self.tts_backend.addItem("", "autodl")
         self.tts_url = QLineEdit()
         self.tts_timeout = self._spinbox(10, 900)
         self.tts_engine_root = QLineEdit()
@@ -1220,10 +981,6 @@ class SettingsDialog(QDialog):
         self.tts_model_dir = QLineEdit()
         self.tts_model_browse = QPushButton()
         self.tts_model_browse.clicked.connect(self._browse_tts_model)
-        self.tts_autodl_ssh_command = QLineEdit()
-        self.tts_autodl_password = self._password_field()
-        self.tts_autodl_remote_command = QLineEdit()
-        self.tts_autodl_reference_root = QLineEdit()
         self.tts_status = QLabel()
         self.tts_status.setWordWrap(True)
         self.tts_progress = QProgressBar()
@@ -1236,10 +993,6 @@ class SettingsDialog(QDialog):
         self.tts_download_button.setEnabled(False)
         self.tts_download_button.clicked.connect(
             self._request_tts_download
-        )
-        self.tts_macos_setup_button = QPushButton()
-        self.tts_macos_setup_button.clicked.connect(
-            self._setup_macos_tts
         )
         self.tts_service_button = QPushButton()
         self.tts_service_button.setEnabled(False)
@@ -1255,14 +1008,16 @@ class SettingsDialog(QDialog):
             self._browse_whisper_model
         )
         self.stt_device = QComboBox()
-        self.stt_device.addItem("", "auto")
-        self.stt_device.addItem("", "cuda")
-        self.stt_device.addItem("", "cpu")
+        self.stt_device.addItems(["auto", "cuda", "cpu"])
         self.stt_input_device = QComboBox()
-        self._default_audio_input = None
+        self._default_audio_input = default_audio_input_device()
         self._missing_audio_input_identifier = ""
         self.stt_input_device.addItem("", "")
-        self._refresh_audio_input_devices(force=True)
+        for input_device in list_audio_input_devices():
+            self.stt_input_device.addItem(
+                input_device.display_name,
+                input_device.identifier,
+            )
         self.whisper_status = QLabel()
         self.whisper_status.setWordWrap(True)
         self.whisper_progress = QProgressBar()
@@ -1273,7 +1028,6 @@ class SettingsDialog(QDialog):
             self._download_whisper_model
         )
         tts_form.addRow(self.tts_enabled)
-        self._add_row(tts_form, "tts_backend", self.tts_backend)
         self._add_row(tts_form, "tts_endpoint", self.tts_url)
         self._add_row(tts_form, "tts_timeout", self.tts_timeout)
         self._add_row(
@@ -1292,28 +1046,7 @@ class SettingsDialog(QDialog):
                 self.tts_model_browse,
             ),
         )
-        self._add_row(
-            tts_form,
-            "tts_autodl_ssh_command",
-            self.tts_autodl_ssh_command,
-        )
-        self._add_row(
-            tts_form,
-            "tts_autodl_password",
-            self.tts_autodl_password,
-        )
-        self._add_row(
-            tts_form,
-            "tts_autodl_remote_command",
-            self.tts_autodl_remote_command,
-        )
-        self._add_row(
-            tts_form,
-            "tts_autodl_reference_root",
-            self.tts_autodl_reference_root,
-        )
         tts_form.addRow(self.tts_status)
-        tts_form.addRow(self.tts_macos_setup_button)
         tts_form.addRow(self.tts_service_button)
         tts_form.addRow(self.tts_progress)
         tts_form.addRow(self.tts_extract_progress)
@@ -1412,17 +1145,11 @@ class SettingsDialog(QDialog):
         layout = QVBoxLayout(page)
         self.automation_group = QGroupBox()
         behavior_form = QFormLayout(self.automation_group)
-        self.automation_help_button = self._help_button(
-            "automation_help_title",
-            "automation_help_body",
-        )
-        behavior_form.addRow(
-            self._right_aligned_widget(self.automation_help_button)
-        )
         self.thinking_minutes = self._spinbox(1, 1_440)
         self.away_minutes = self._spinbox(2, 1_440)
         self.history_limit = self._spinbox(4, 200)
         self.do_not_disturb = QCheckBox()
+        self.clear_history_button = QPushButton()
         self._add_row(
             behavior_form,
             "thinking_reminder",
@@ -1435,6 +1162,11 @@ class SettingsDialog(QDialog):
             self.history_limit,
         )
         behavior_form.addRow(self.do_not_disturb)
+        behavior_form.addRow(self.clear_history_button)
+        self.clear_history_button.setEnabled(not self._first_run)
+        self.clear_history_button.clicked.connect(
+            self._confirm_clear_history
+        )
         layout.addWidget(self.automation_group)
         layout.addStretch(1)
         return page
@@ -1444,13 +1176,6 @@ class SettingsDialog(QDialog):
         layout = QVBoxLayout(page)
         self.display_group = QGroupBox()
         display_form = QFormLayout(self.display_group)
-        self.display_help_button = self._help_button(
-            "display_help_title",
-            "display_help_body",
-        )
-        display_form.addRow(
-            self._right_aligned_widget(self.display_help_button)
-        )
         self.screen_index = self._spinbox(0, 32)
         self.portrait_ratio = QDoubleSpinBox()
         self.portrait_ratio.setRange(0.2, 1.0)
@@ -1465,32 +1190,6 @@ class SettingsDialog(QDialog):
         )
         display_form.addRow(self.show_log_console)
         layout.addWidget(self.display_group)
-        layout.addStretch(1)
-        return page
-
-    def _build_other_tab(self) -> QWidget:
-        page = QWidget()
-        layout = QVBoxLayout(page)
-        self.data_group = QGroupBox()
-        data_form = QFormLayout(self.data_group)
-        self.clear_history_button = QPushButton()
-        self.clear_history_button.setEnabled(not self._first_run)
-        self.clear_history_button.clicked.connect(
-            self._confirm_clear_history
-        )
-        self.clear_cache_button = QPushButton()
-        self.clear_cache_button.clicked.connect(self._confirm_clear_cache)
-        self._add_row(
-            data_form,
-            "conversation_history_data",
-            self.clear_history_button,
-        )
-        self._add_row(
-            data_form,
-            "runtime_cache_data",
-            self.clear_cache_button,
-        )
-        layout.addWidget(self.data_group)
         layout.addStretch(1)
         return page
 
@@ -1619,25 +1318,15 @@ class SettingsDialog(QDialog):
             settings.vision.openai_model,
         )
         self.tts_enabled.setChecked(settings.tts.enabled)
-        self._set_combo_data(self.tts_backend, settings.tts.backend)
         self.tts_url.setText(settings.tts.base_url)
         self.tts_timeout.setValue(settings.tts.timeout_seconds)
         self.tts_engine_root.setText(settings.tts.engine_root)
         self.tts_model_dir.setText(settings.tts.model_dir)
-        self.tts_autodl_ssh_command.setText(
-            settings.tts.autodl_ssh_command
-        )
-        self.tts_autodl_remote_command.setText(
-            settings.tts.autodl_remote_command
-        )
-        self.tts_autodl_reference_root.setText(
-            settings.tts.autodl_remote_reference_root
-        )
         self.stt_enabled.setChecked(settings.stt.enabled)
         self._set_editable_combo(self.stt_model, settings.stt.model)
         self.whisper_model_dir.setText(settings.stt.model_dir)
         self._set_audio_input_device(settings.stt.input_device)
-        self._set_combo_data(self.stt_device, settings.stt.device)
+        self.stt_device.setCurrentText(settings.stt.device)
         self.screen_index.setValue(settings.display.screen_index)
         self.portrait_ratio.setValue(
             settings.display.portrait_screen_ratio
@@ -1667,43 +1356,6 @@ class SettingsDialog(QDialog):
             self._missing_audio_input_identifier = identifier
             index = self.stt_input_device.count() - 1
         self.stt_input_device.setCurrentIndex(max(index, 0))
-
-    def _refresh_audio_input_devices(self, force: bool = False) -> None:
-        if not hasattr(self, "stt_input_device"):
-            return
-        default_device, input_devices = refresh_audio_input_devices()
-        signature: tuple[object, ...] = (
-            (
-                default_device.identifier,
-                default_device.display_name,
-            )
-            if default_device is not None
-            else None,
-            tuple(
-                (device.identifier, device.display_name)
-                for device in input_devices
-            ),
-        )
-        if not force and signature == self._audio_device_signature:
-            return
-
-        selected = self.stt_input_device.currentData() or ""
-        self._audio_device_signature = signature
-        self._default_audio_input = default_device
-        self._missing_audio_input_identifier = ""
-        self.stt_input_device.blockSignals(True)
-        try:
-            self.stt_input_device.clear()
-            self.stt_input_device.addItem("", "")
-            for input_device in input_devices:
-                self.stt_input_device.addItem(
-                    input_device.display_name,
-                    input_device.identifier,
-                )
-            self._set_audio_input_device(selected)
-            self._retranslate_audio_input_devices()
-        finally:
-            self.stt_input_device.blockSignals(False)
 
     def _retranslate_audio_input_devices(self) -> None:
         default_name = (
@@ -1747,7 +1399,6 @@ class SettingsDialog(QDialog):
         self.tabs.setTabText(2, self._text("tab_character"))
         self.tabs.setTabText(3, self._text("tab_automation"))
         self.tabs.setTabText(4, self._text("tab_display"))
-        self.tabs.setTabText(5, self._text("tab_other"))
 
         self.backend_group.setTitle(self._text("backend_group"))
         self.ollama_group.setTitle(self._text("ollama_group"))
@@ -1759,7 +1410,6 @@ class SettingsDialog(QDialog):
         self.whisper_group.setTitle(self._text("whisper_group"))
         self.automation_group.setTitle(self._text("automation_group"))
         self.display_group.setTitle(self._text("display_group"))
-        self.data_group.setTitle(self._text("data_group"))
 
         for key, labels in self._form_labels.items():
             for label in labels:
@@ -1801,16 +1451,6 @@ class SettingsDialog(QDialog):
             self._text("vision_provider_openai"),
         )
         self._set_combo_item_text(
-            self.tts_backend,
-            "local",
-            self._text("tts_backend_local"),
-        )
-        self._set_combo_item_text(
-            self.tts_backend,
-            "autodl",
-            self._text("tts_backend_autodl"),
-        )
-        self._set_combo_item_text(
             self.portrait,
             "a",
             self._text("portrait_a"),
@@ -1829,14 +1469,6 @@ class SettingsDialog(QDialog):
 
         self.deepseek_thinking.setText(self._text("deepseek_thinking"))
         self.do_not_disturb.setText(self._text("do_not_disturb"))
-        self.automation_help_button.setToolTip(self._text("settings_help"))
-        self.automation_help_button.setAccessibleName(
-            self._text("settings_help")
-        )
-        self.display_help_button.setToolTip(self._text("settings_help"))
-        self.display_help_button.setAccessibleName(
-            self._text("settings_help")
-        )
         self.clear_history_button.setText(self._text("clear_history"))
         self.clear_history_button.setToolTip(
             (
@@ -1845,7 +1477,6 @@ class SettingsDialog(QDialog):
                 else self._text("history_unavailable_first_run")
             )
         )
-        self.clear_cache_button.setText(self._text("clear_cache"))
         self.deepseek_note.setText(self._text("deepseek_note"))
         self.fetch_models_button.setText(self._text("load_models"))
         self.model_list_help.setText(self._text("model_list_help"))
@@ -1865,35 +1496,12 @@ class SettingsDialog(QDialog):
             self._text("show_log_console")
         )
         self.tts_enabled.setText(self._text("tts_enabled"))
-        self.tts_autodl_password.setPlaceholderText(
-            self._text("tts_autodl_password_placeholder")
-        )
         self.tts_engine_browse.setText(self._text("browse"))
         self.tts_model_browse.setText(self._text("browse"))
         self.tts_download_button.setText(self._text("tts_download"))
-        self.tts_macos_setup_button.setText(self._text("tts_macos_setup"))
         self._render_tts_service_button()
-        self.stt_enabled.setText(
-            self._text(
-                "stt_enabled_macos" if sys.platform == "darwin" else "stt_enabled"
-            )
-        )
+        self.stt_enabled.setText(self._text("stt_enabled"))
         self._retranslate_audio_input_devices()
-        self._set_combo_item_text(
-            self.stt_device,
-            "auto",
-            self._text("stt_device_auto"),
-        )
-        self._set_combo_item_text(
-            self.stt_device,
-            "cuda",
-            self._text("stt_device_cuda"),
-        )
-        self._set_combo_item_text(
-            self.stt_device,
-            "cpu",
-            self._text("stt_device_cpu"),
-        )
         self.whisper_download_button.setText(
             self._text("whisper_download")
         )
@@ -2161,106 +1769,23 @@ class SettingsDialog(QDialog):
             detail=detail,
         )
 
-    def _on_tts_backend_changed(self) -> None:
-        manager = get_tts_service_manager()
-        if manager.owns_running_process():
-            manager.stop()
-        if self.tts_backend.currentData() == "autodl":
-            self.tts_url.setText("http://127.0.0.1:9880/tts")
-        self._update_tts_state()
-
-    def _current_tts_settings(
-        self,
-        *,
-        enabled: bool | None = None,
-    ) -> TTSSettings:
-        return TTSSettings(
-            enabled=(
-                self.tts_enabled.isChecked()
-                if enabled is None
-                else enabled
-            ),
-            backend=self.tts_backend.currentData() or "local",
-            base_url=self.tts_url.text().strip(),
-            engine_root=self.tts_engine_root.text().strip(),
-            model_dir=self.tts_model_dir.text().strip(),
-            autodl_ssh_command=(
-                self.tts_autodl_ssh_command.text().strip()
-            ),
-            autodl_remote_command=(
-                self.tts_autodl_remote_command.text().strip()
-            ),
-            autodl_remote_reference_root=(
-                self.tts_autodl_reference_root.text().strip()
-            ),
-            autodl_password_encrypted=(
-                self._original.tts.autodl_password_encrypted
-            ),
-            timeout_seconds=self.tts_timeout.value(),
-        )
-
     def _set_tts_path_controls(self, *, downloading: bool) -> None:
         enabled = self.tts_enabled.isChecked()
-        autodl = self.tts_backend.currentData() == "autodl"
-        controls_enabled = enabled and not downloading
-        local_enabled = controls_enabled and not autodl
-        autodl_enabled = controls_enabled and autodl
-        local_keys = (
-            "tts_endpoint",
-            "tts_engine_root",
-            "tts_model_dir",
+        local_endpoint = is_loopback_url(self.tts_url.text().strip())
+        self.tts_engine_root.setEnabled(
+            enabled and local_endpoint and not downloading
         )
-        autodl_keys = (
-            "tts_autodl_ssh_command",
-            "tts_autodl_password",
-            "tts_autodl_remote_command",
-            "tts_autodl_reference_root",
+        self.tts_engine_browse.setEnabled(
+            enabled and local_endpoint and not downloading
         )
-
-        self.tts_backend.setEnabled(controls_enabled)
-        self.tts_timeout.setEnabled(controls_enabled)
-        self.tts_url.setEnabled(local_enabled)
-        self.tts_engine_root.setEnabled(local_enabled)
-        self.tts_engine_browse.setEnabled(local_enabled)
-        self.tts_model_dir.setEnabled(local_enabled)
-        self.tts_model_browse.setEnabled(local_enabled)
-        for field in (
-            self.tts_autodl_ssh_command,
-            self.tts_autodl_password,
-            self.tts_autodl_remote_command,
-            self.tts_autodl_reference_root,
-        ):
-            field.setEnabled(autodl_enabled)
-
-        self._set_form_rows_visible(local_keys, not autodl)
-        self._set_form_rows_visible(autodl_keys, autodl)
-        self.tts_download_button.setVisible(not autodl)
-        self.tts_macos_setup_button.setVisible(
-            sys.platform == "darwin" and not autodl
-        )
-        self.tts_macos_setup_button.setEnabled(local_enabled)
-        if autodl:
-            self.tts_progress.hide()
-            self.tts_extract_progress.hide()
-
-        self._set_form_labels_enabled(
-            ("tts_backend", "tts_timeout"),
-            controls_enabled,
-        )
-        self._set_form_labels_enabled(
-            local_keys,
-            local_enabled,
-        )
-        self._set_form_labels_enabled(
-            autodl_keys,
-            autodl_enabled,
-        )
+        self.tts_model_dir.setEnabled(enabled and not downloading)
+        self.tts_model_browse.setEnabled(enabled and not downloading)
 
     def _update_tts_state(self) -> None:
         if not hasattr(self, "tts_status"):
             return
         enabled = self.tts_enabled.isChecked()
-        autodl = self.tts_backend.currentData() == "autodl"
+        local_endpoint = is_loopback_url(self.tts_url.text().strip())
         snapshot = self.download_manager.snapshot(TTS_JOB_ID)
         downloading = snapshot.status in {
             "preparing",
@@ -2272,7 +1797,7 @@ class SettingsDialog(QDialog):
         }
         self._set_tts_path_controls(downloading=downloading)
         self.tts_download_button.setEnabled(False)
-        self.tts_service_button.setVisible(True)
+        self.tts_service_button.setVisible(local_endpoint)
         self._set_tts_service_button("start", False)
         if (
             self._tts_service_worker is not None
@@ -2295,7 +1820,13 @@ class SettingsDialog(QDialog):
             self._set_tts_status("tts_checking")
             return
         try:
-            settings = self._current_tts_settings(enabled=True)
+            settings = TTSSettings(
+                enabled=True,
+                base_url=self.tts_url.text().strip(),
+                engine_root=self.tts_engine_root.text().strip(),
+                model_dir=self.tts_model_dir.text().strip(),
+                timeout_seconds=self.tts_timeout.value(),
+            )
         except ValidationError:
             self._set_tts_status("tts_invalid")
             return
@@ -2313,27 +1844,10 @@ class SettingsDialog(QDialog):
     ) -> None:
         if self._closing or not self.tts_enabled.isChecked():
             return
-        autodl = self.tts_backend.currentData() == "autodl"
-        if autodl:
-            self._tts_engine_download_needed = False
-            if reachable:
-                if get_tts_service_manager().owns_running_process():
-                    self._set_tts_service_button("stop", True)
-                else:
-                    self._set_tts_service_button("online", False)
-                self._set_tts_status("tts_external_online")
-            else:
-                has_password = bool(
-                    self.tts_autodl_password.text()
-                    or self._original.tts.autodl_password_encrypted
-                )
-                can_start = bool(
-                    self.tts_autodl_ssh_command.text().strip()
-                    and self.tts_autodl_remote_command.text().strip()
-                    and has_password
-                )
-                self._set_tts_service_button("start", can_start)
-                self._set_tts_status("tts_external_offline")
+        local_endpoint = is_loopback_url(self.tts_url.text().strip())
+        if not local_endpoint:
+            key = "tts_external_online" if reachable else "tts_external_offline"
+            self._set_tts_status(key)
             return
 
         configured_engine = self.tts_engine_root.text().strip()
@@ -2382,7 +1896,6 @@ class SettingsDialog(QDialog):
                 self._set_tts_status("tts_ready_offline")
             if (
                 self._tts_engine_download_needed
-                and sys.platform != "darwin"
                 and not self._tts_download_prompted
             ):
                 self._tts_download_prompted = True
@@ -2422,7 +1935,13 @@ class SettingsDialog(QDialog):
         ):
             return
         try:
-            settings = self._current_tts_settings(enabled=True)
+            settings = TTSSettings(
+                enabled=True,
+                base_url=self.tts_url.text().strip(),
+                engine_root=self.tts_engine_root.text().strip(),
+                model_dir=self.tts_model_dir.text().strip(),
+                timeout_seconds=self.tts_timeout.value(),
+            )
         except ValidationError:
             self._set_tts_status("tts_invalid")
             return
@@ -2437,18 +1956,9 @@ class SettingsDialog(QDialog):
         self._set_tts_status(
             "tts_service_stopping"
             if action == "stop"
-            else (
-                "tts_service_connecting_ssh"
-                if settings.uses_autodl()
-                else "tts_service_locating"
-            )
+            else "tts_service_locating"
         )
-        worker = TTSServiceWorker(
-            settings,
-            action,
-            self.tts_autodl_password.text(),
-            self,
-        )
+        worker = TTSServiceWorker(settings, action, self)
         self._tts_service_worker = worker
         worker.stage_changed.connect(self._on_tts_service_stage)
         worker.succeeded.connect(self._on_tts_service_succeeded)
@@ -2462,37 +1972,12 @@ class SettingsDialog(QDialog):
         key = {
             "locating_engine": "tts_service_locating",
             "starting_process": "tts_service_starting",
-            "connecting_ssh": "tts_service_connecting_ssh",
-            "starting_remote": "tts_service_starting_remote",
-            "starting_tunnel": "tts_service_starting_tunnel",
             "waiting_for_api": "tts_service_waiting",
             "waiting_for_existing_start": "tts_service_waiting_existing",
             "loading_weights": "tts_service_loading_weights",
         }.get(stage)
         if key is not None:
             self._set_tts_status(key)
-
-    def _setup_macos_tts(self) -> None:
-        if sys.platform != "darwin":
-            return
-        script = PROJECT_ROOT / "install_macos_tts.command"
-        if not script.is_file():
-            self._set_tts_status(
-                "tts_service_failed",
-                message="install_macos_tts.command was not found.",
-            )
-            return
-        self.tts_engine_root.setText(str(managed_gpt_sovits_dir()))
-        self.tts_model_dir.setText(str(managed_tts_model_dir()))
-        try:
-            subprocess.Popen(
-                ["open", "-a", "Terminal", str(script)],
-                cwd=str(PROJECT_ROOT),
-            )
-        except OSError as exc:
-            self._set_tts_status("tts_service_failed", message=str(exc))
-            return
-        self._set_tts_status("tts_macos_setup_opened")
 
     def _on_tts_service_succeeded(self, action: str) -> None:
         self._set_tts_status(
@@ -2522,18 +2007,23 @@ class SettingsDialog(QDialog):
     def _request_tts_download(self) -> None:
         if not self.tts_enabled.isChecked():
             return
-        if self.tts_backend.currentData() == "autodl":
-            return
         model_destination = self._require_download_directory(
             self.tts_model_dir,
             "tts_model_path_required",
         )
         if model_destination is None:
             return
-        include_engine = (
-            self._tts_engine_download_needed and sys.platform != "darwin"
-        )
+        include_engine = self._tts_engine_download_needed
         engine_destination = None
+        if sys.platform == "darwin" and include_engine:
+            QMessageBox.information(
+                self,
+                "GPT-SoVITS",
+                "macOS 不使用项目提供的 Windows GPT-SoVITS 整合包。"
+                "请按 GPT-SoVITS 官方说明准备本地引擎，再在此处选择目录；"
+                "本次只下载丛雨语音模型和参考音频。",
+            )
+            include_engine = False
         if include_engine:
             engine_destination = self._require_download_directory(
                 self.tts_engine_root,
@@ -2545,16 +2035,9 @@ class SettingsDialog(QDialog):
             self,
             self._text("tts_download_consent_title"),
             self._text(
-                "tts_download_consent_body_macos"
-                if (
-                    sys.platform == "darwin"
-                    and self._tts_engine_download_needed
-                )
-                else (
-                    "tts_download_consent_body_with_engine"
-                    if include_engine
-                    else "tts_download_consent_body"
-                )
+                "tts_download_consent_body_with_engine"
+                if include_engine
+                else "tts_download_consent_body"
             ),
             QMessageBox.Yes | QMessageBox.No,
             QMessageBox.Yes,
@@ -2660,6 +2143,7 @@ class SettingsDialog(QDialog):
                 self._set_tts_path_controls(downloading=False)
                 self.tts_download_button.setEnabled(
                     self.tts_enabled.isChecked()
+                    and is_loopback_url(self.tts_url.text().strip())
                 )
                 self._render_progress(self.tts_progress, snapshot)
                 self.tts_extract_progress.hide()
@@ -2934,44 +2418,6 @@ class SettingsDialog(QDialog):
         self.clear_history_requested.emit()
         self._set_status("history_cleared")
 
-    def _confirm_clear_cache(self) -> None:
-        answer = QMessageBox.question(
-            self,
-            self._text("clear_cache_confirm_title"),
-            self._text("clear_cache_confirm_body"),
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
-        )
-        if answer != QMessageBox.Yes:
-            return
-
-        result = clear_runtime_cache()
-        values = {
-            "files": result.removed_files,
-            "size": self._format_byte_count(result.removed_bytes),
-        }
-        if result.failed_paths:
-            self._set_status(
-                "cache_clear_partial",
-                failed=len(result.failed_paths),
-                **values,
-            )
-        elif result.removed_files:
-            self._set_status("cache_cleared", **values)
-        else:
-            self._set_status("cache_empty")
-
-    @staticmethod
-    def _format_byte_count(byte_count: int) -> str:
-        size = float(max(0, byte_count))
-        for unit in ("B", "KiB", "MiB", "GiB"):
-            if size < 1024 or unit == "GiB":
-                if unit == "B":
-                    return f"{int(size)} {unit}"
-                return f"{size:.1f} {unit}"
-            size /= 1024
-        return f"{size:.1f} GiB"
-
     def _form_settings(self) -> AppSettings:
         personality_path = get_user_data_dir() / "personality.txt"
         screen_index = self.screen_index.value()
@@ -3032,12 +2478,18 @@ class SettingsDialog(QDialog):
                 ),
                 timeout_seconds=self.vision_timeout.value(),
             ),
-            tts=self._current_tts_settings(),
+            tts=TTSSettings(
+                enabled=self.tts_enabled.isChecked(),
+                base_url=self.tts_url.text().strip(),
+                engine_root=self.tts_engine_root.text().strip(),
+                model_dir=self.tts_model_dir.text().strip(),
+                timeout_seconds=self.tts_timeout.value(),
+            ),
             stt=STTSettings(
                 enabled=self.stt_enabled.isChecked(),
                 model=self.stt_model.currentText().strip(),
                 model_dir=self.whisper_model_dir.text().strip(),
-                device=self.stt_device.currentData(),
+                device=self.stt_device.currentText(),
                 input_device=self.stt_input_device.currentData() or "",
             ),
             character=CharacterSettings(
@@ -3243,40 +2695,6 @@ class SettingsDialog(QDialog):
                 self._text("missing_key_body"),
             )
             return
-        if settings.tts.enabled and settings.tts.uses_autodl():
-            has_password = bool(
-                self.tts_autodl_password.text()
-                or settings.tts.autodl_password_encrypted
-            )
-            if not all(
-                (
-                    settings.tts.autodl_ssh_command.strip(),
-                    settings.tts.autodl_remote_command.strip(),
-                    settings.tts.autodl_remote_reference_root.strip(),
-                    has_password,
-                )
-            ):
-                QMessageBox.warning(
-                    self,
-                    self._text("invalid_settings"),
-                    self._text("tts_autodl_missing"),
-                )
-                return
-            if self.tts_autodl_password.text():
-                try:
-                    settings.tts.autodl_password_encrypted = protect_secret(
-                        self.tts_autodl_password.text()
-                    )
-                except CredentialError as exc:
-                    QMessageBox.warning(
-                        self,
-                        self._text("invalid_settings"),
-                        self._text(
-                            "tts_password_store_failed",
-                            message=exc,
-                        ),
-                    )
-                    return
 
         personality_path = settings.personality_path()
         try:


### PR DESCRIPTION
## V2.0.1 macOS 适配

本 PR 基于上游 V2.0.1，补充 Apple Silicon macOS 所需的原生启动、全屏 Space 兼容、Cocoa/CoreGraphics 原生覆盖层，以及 macOS 下的 GPT-SoVITS 安装指引，同时保持上游项目的功能和设置结构。

### 适配范围
- macOS 原生启动脚本和全屏兼容覆盖层。
- macOS 下的本地语音合成安装指引。
- 保持上游项目的功能结构和使用方式。

已在 Apple Silicon macOS 上完成编译和基础检查。