### PR TITLE
同步 macOS 稳定性修复到 main

### DIFF
--- a/aipet/platforms/macos/fullscreen_overlay.py
+++ b/aipet/platforms/macos/fullscreen_overlay.py
@@ -63,6 +63,10 @@ class FullscreenOverlay:
 
     def sync(self) -> None:
         if self._process is None or self._process.poll() is not None:
+            if self._was_fullscreen and not self._widget.isVisible():
+                self._widget.show()
+            self._was_fullscreen = False
+            self._process = None
             return
         fullscreen = self._state.read_text(encoding="utf-8").strip() == "1"
         if fullscreen and not self._was_fullscreen:

--- a/aipet/platforms/macos/tts_bootstrap.py
+++ b/aipet/platforms/macos/tts_bootstrap.py
@@ -20,9 +20,6 @@ from urllib.request import Request, urlopen
 import certifi
 
 
-_REPOSITORY = "https://github.com/RVC-Boss/GPT-SoVITS.git"
-_TAG = "20250606v2pro"
-_COMMIT = "d7c2210da8c013e81a94bfc7b811a477c99fd506"
 _PYTHON_VERSION = "3.10.20"
 _MODEL_BASE = (
     "https://www.modelscope.cn/models/"
@@ -101,31 +98,59 @@ class MacOSTTSBootstrap:
             f".{engine_root.name}-install-{uuid.uuid4().hex}"
         )
         try:
-            progress("Downloading GPT-SoVITS source")
-            self._run(
-                [
-                    "git",
-                    "clone",
-                    "--depth",
-                    "1",
-                    "--branch",
-                    _TAG,
-                    _REPOSITORY,
-                    str(staging),
-                ]
-            )
-            actual = self._output(["git", "-C", str(staging), "rev-parse", "HEAD"])
-            if actual != _COMMIT:
+            bundle, checksum = self._packaged_source()
+            if not bundle.is_file() or not checksum.is_file():
                 raise RuntimeError(
-                    "GPT-SoVITS source verification failed; the expected "
-                    "release commit was not received."
+                    "The packaged GPT-SoVITS source is missing. Reinstall "
+                    "AIpet-Murasame from the macOS DMG."
                 )
+            expected = checksum.read_text(encoding="utf-8").split()[0]
+            actual = self._sha256(bundle)
+            if actual != expected:
+                raise RuntimeError(
+                    "The packaged GPT-SoVITS source failed verification."
+                )
+            progress("Installing packaged GPT-SoVITS source")
+            self._extract_zip(bundle, staging)
+            roots = [
+                path
+                for path in staging.iterdir()
+                if path.is_dir() and (path / "api_v2.py").is_file()
+            ]
+            if len(roots) != 1:
+                raise RuntimeError("The packaged GPT-SoVITS source is invalid.")
             if engine_root.exists():
                 engine_root.rmdir()
-            os.replace(staging, engine_root)
+            os.replace(roots[0], engine_root)
         finally:
             if staging.exists():
                 shutil.rmtree(staging, ignore_errors=True)
+
+    @staticmethod
+    def _packaged_source() -> tuple[Path, Path]:
+        bundle_root = Path(getattr(sys, "_MEIPASS", ""))
+        contents = Path(sys.executable).resolve().parents[1]
+        candidates = [
+            bundle_root / "tools",
+            contents / "Frameworks" / "tools",
+            contents / "Resources" / "tools",
+        ]
+        for directory in candidates:
+            bundle = directory / "gpt-sovits-source.zip"
+            checksum = directory / "gpt-sovits-source.sha256"
+            if bundle.is_file() and checksum.is_file():
+                return bundle, checksum
+        return Path(), Path()
+
+    @staticmethod
+    def _sha256(path: Path) -> str:
+        import hashlib
+
+        digest = hashlib.sha256()
+        with path.open("rb") as source:
+            for chunk in iter(lambda: source.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
 
     def _install_python(
         self,
@@ -415,14 +440,3 @@ class MacOSTTSBootstrap:
             raise RuntimeError(
                 f"GPT-SoVITS installation command failed ({result.returncode}): {detail}"
             )
-
-    @staticmethod
-    def _output(command: list[str]) -> str:
-        result = subprocess.run(
-            command,
-            check=True,
-            capture_output=True,
-            text=True,
-            errors="replace",
-        )
-        return result.stdout.strip()

--- a/aipet/platforms/macos/voice_trigger.py
+++ b/aipet/platforms/macos/voice_trigger.py
@@ -10,6 +10,10 @@ from AppKit import (
     NSEventTypeKeyDown,
     NSEventTypeKeyUp,
 )
+from ApplicationServices import (
+    AXIsProcessTrustedWithOptions,
+    kAXTrustedCheckOptionPrompt,
+)
 
 from aipet.core.runtime_logging import get_logger
 from aipet.core.voice_input import HoldToTalkSession
@@ -27,6 +31,12 @@ class OptionVVoiceTrigger(HoldToTalkSession):
     def start(self) -> None:
         if self._monitors:
             return
+        if not self._has_accessibility_permission():
+            raise PermissionError(
+                "Option+V requires Accessibility permission. "
+                "Allow AIpet-Murasame in System Settings > Privacy & Security "
+                "> Accessibility, then try again."
+            )
         mask = NSEventMaskKeyDown | NSEventMaskKeyUp
         global_monitor = NSEvent.addGlobalMonitorForEventsMatchingMask_handler_(
             mask,
@@ -38,6 +48,14 @@ class OptionVVoiceTrigger(HoldToTalkSession):
         )
         self._monitors = [global_monitor, local_monitor]
         logger.info("Option+V 语音触发已启动")
+
+    @staticmethod
+    def _has_accessibility_permission() -> bool:
+        return bool(
+            AXIsProcessTrustedWithOptions(
+                {kAXTrustedCheckOptionPrompt: True}
+            )
+        )
 
     def stop(self) -> None:
         self.stop_session()

--- a/packaging/macos/AIpet-macOS.spec
+++ b/packaging/macos/AIpet-macOS.spec
@@ -10,6 +10,8 @@ project_root = Path(SPECPATH).parents[1]
 icon_path = Path(os.environ["AIPET_MACOS_ICON"])
 uv_path = Path(os.environ["AIPET_MACOS_UV"])
 overlay_path = Path(os.environ["AIPET_MACOS_FULLSCREEN_OVERLAY"])
+gpt_sovits_source = Path(os.environ["AIPET_MACOS_GPT_SOVITS_SOURCE"])
+gpt_sovits_checksum = Path(os.environ["AIPET_MACOS_GPT_SOVITS_CHECKSUM"])
 
 datas = [
     (str(project_root / "fgimages"), "fgimages"),
@@ -17,6 +19,8 @@ datas = [
     (str(project_root / "icon.png"), "."),
     (str(project_root / "思源黑体Bold.otf"), "."),
     (str(uv_path), "tools"),
+    (str(gpt_sovits_source), "tools"),
+    (str(gpt_sovits_checksum), "tools"),
     (str(overlay_path), "aipet-fullscreen-overlay"),
 ]
 datas += collect_data_files("faster_whisper")

--- a/packaging/macos/build_dmg.sh
+++ b/packaging/macos/build_dmg.sh
@@ -29,6 +29,15 @@ iconutil -c icns "$iconset" -o "$icon_file"
 
 export AIPET_MACOS_ICON="$icon_file"
 export AIPET_MACOS_UV="$venv_root/bin/uv"
+gpt_sovits_source="$build_root/gpt-sovits-source.zip"
+gpt_sovits_checksum="$build_root/gpt-sovits-source.sha256"
+curl --fail --location --retry 3 \
+  --output "$gpt_sovits_source.partial" \
+  "https://github.com/RVC-Boss/GPT-SoVITS/archive/d7c2210da8c013e81a94bfc7b811a477c99fd506.zip"
+mv "$gpt_sovits_source.partial" "$gpt_sovits_source"
+shasum -a 256 "$gpt_sovits_source" > "$gpt_sovits_checksum"
+export AIPET_MACOS_GPT_SOVITS_SOURCE="$gpt_sovits_source"
+export AIPET_MACOS_GPT_SOVITS_CHECKSUM="$gpt_sovits_checksum"
 overlay_binary="$build_root/aipet-fullscreen-overlay"
 clang -framework Cocoa -framework CoreGraphics \
   "$project_root/aipet/platforms/macos/fullscreen_overlay.m" \
@@ -42,6 +51,10 @@ export AIPET_MACOS_FULLSCREEN_OVERLAY="$overlay_binary"
   "$script_dir/AIpet-macOS.spec"
 
 app_path="$dist_root/AIpet-Murasame.app"
+codesign --force --sign - \
+  "$app_path/Contents/Frameworks/tools/uv"
+codesign --force --sign - \
+  "$app_path/Contents/Frameworks/aipet-fullscreen-overlay/aipet-fullscreen-overlay"
 codesign --force --deep --sign - "$app_path"
 
 dmg_path="$dist_root/AIpet-Murasame.dmg"

--- a/tests/test_platforms.py
+++ b/tests/test_platforms.py
@@ -4,6 +4,7 @@ import sys
 import tempfile
 import types
 import unittest
+import zipfile
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
@@ -228,6 +229,22 @@ class PlatformArchitectureTests(unittest.TestCase):
         overlay.sync.assert_called_once_with()
         configure_windows.assert_not_called()
 
+    def test_macos_overlay_restores_qt_window_after_process_exit(self) -> None:
+        from aipet.platforms.macos.fullscreen_overlay import FullscreenOverlay
+
+        widget = Mock()
+        widget.isVisible.return_value = False
+        overlay = FullscreenOverlay(widget)
+        overlay._process = Mock()
+        overlay._process.poll.return_value = 1
+        overlay._was_fullscreen = True
+
+        overlay.sync()
+
+        widget.show.assert_called_once_with()
+        self.assertFalse(overlay.is_fullscreen)
+        self.assertIsNone(overlay._process)
+
     def test_macos_tool_window_is_kept_visible_across_spaces(self) -> None:
         integration = MacOSWindowIntegration()
         widget = Mock()
@@ -436,22 +453,45 @@ class PlatformArchitectureTests(unittest.TestCase):
             ):
                 self.assertEqual(MacOSTTSBootstrap._uv(), uv.resolve())
 
+    def test_macos_tts_bootstrap_finds_packaged_source(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            contents = Path(directory) / "Contents"
+            executable = contents / "MacOS" / "AIpet-Murasame"
+            bundle = contents / "Frameworks" / "tools" / "gpt-sovits-source.zip"
+            checksum = bundle.with_suffix(".sha256")
+            executable.parent.mkdir(parents=True)
+            executable.touch()
+            bundle.parent.mkdir(parents=True)
+            bundle.touch()
+            checksum.write_text("digest", encoding="utf-8")
+
+            with (
+                patch.object(sys, "frozen", True, create=True),
+                patch.object(sys, "executable", str(executable)),
+            ):
+                self.assertEqual(
+                    MacOSTTSBootstrap._packaged_source(),
+                    (bundle.resolve(), checksum.resolve()),
+                )
+
     def test_macos_tts_bootstrap_replaces_empty_engine_directory(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory) / "GPT-SoVITS"
             root.mkdir()
+            bundle = Path(directory) / "gpt-sovits-source.zip"
+            checksum = Path(directory) / "gpt-sovits-source.sha256"
+            with zipfile.ZipFile(bundle, "w") as contents:
+                contents.writestr("GPT-SoVITS-test/api_v2.py", "")
+            checksum.write_text(
+                MacOSTTSBootstrap._sha256(bundle),
+                encoding="utf-8",
+            )
             bootstrap = MacOSTTSBootstrap()
 
-            def clone(command, **_kwargs) -> None:
-                staging = Path(command[-1])
-                staging.mkdir()
-                (staging / "api_v2.py").touch()
-
-            with (
-                patch.object(bootstrap, "_run", side_effect=clone),
-                patch.object(bootstrap, "_output", return_value=(
-                    "d7c2210da8c013e81a94bfc7b811a477c99fd506"
-                )),
+            with patch.object(
+                bootstrap,
+                "_packaged_source",
+                return_value=(bundle, checksum),
             ):
                 bootstrap._install_source(root, lambda _stage: None)
 

--- a/tests/test_voice_trigger.py
+++ b/tests/test_voice_trigger.py
@@ -206,6 +206,19 @@ class WindowsVoiceTriggerTests(unittest.TestCase):
     "macOS voice dependencies are unavailable",
 )
 class MacOSVoiceTriggerTests(unittest.TestCase):
+    def test_macos_start_requests_accessibility_before_monitoring(self) -> None:
+        trigger = OptionVVoiceTrigger(on_text_ready=Mock())
+
+        with patch.object(
+            trigger,
+            "_has_accessibility_permission",
+            return_value=False,
+        ):
+            with self.assertRaises(PermissionError):
+                trigger.start()
+
+        self.assertEqual(trigger._monitors, [])
+
     def test_macos_option_v_controls_hold_session(self) -> None:
         trigger = OptionVVoiceTrigger(on_text_ready=Mock())
         trigger.press = Mock()


### PR DESCRIPTION
## 概要

将 `developing` 中已合并并审核的 macOS 稳定性修复同步到 `main`：

- Option+V 启动时检查并申请辅助功能权限；
- 全屏辅助进程退出后恢复 Qt 桌宠窗口；
- 在 DMG 构建阶段准备并校验 GPT-SoVITS 源码，安装时不再依赖系统 Git/Xcode Command Line Tools；
- 补充对应的跨平台、语音触发和 macOS 回归测试。

包含已合并的 PR #20。

## 验证

- `python -m unittest tests.test_platforms tests.test_voice_trigger tests.test_ui_smoke -q`：52 项通过，3 项平台相关跳过；
- `python -m unittest discover -s tests -q`：128 项通过，3 项平台相关跳过；
- `python -m compileall -q aipet tests`；
- `git diff --check`；
- 上游 PR 已报告通过 macOS DMG 完整性、App 签名及实机全屏、Option+V、TTS 验证。