### PR TITLE
Add macOS V2.0.4 build support

### DIFF
--- a/aipet/platforms/macos/README.md
+++ b/aipet/platforms/macos/README.md
@@ -55,11 +55,31 @@ GPT-SoVITS/python
 The engine directory must contain `api_v2.py` and
 `GPT_SoVITS/configs/tts_infer.yaml`.
 
+## Install the DMG
+
+1. Download `AIpet-Murasame.dmg` from the release page and double-click it to
+   mount.
+2. Drag `AIpet-Murasame.app` into the `Applications` folder.
+3. On first launch macOS may warn that the app "cannot be opened because the
+   developer cannot be verified". This release is ad-hoc signed but not
+   notarized, so do one of the following:
+   - **Right-click** `AIpet-Murasame.app` in `Applications`, choose
+     **Open**, then confirm **Open** in the dialog; or
+   - Remove the quarantine attribute once per download:
+     `xattr -dr com.apple.quarantine /Applications/AIpet-Murasame.app`.
+4. On first use macOS may request Accessibility, Microphone, or Screen
+   Recording permission. Allow them in **System Settings → Privacy &
+   Security** so speech input and fullscreen-space visibility work.
+
+Requires **Apple Silicon** Mac running **macOS 13 or later**.
+
 ## Build the DMG
 
 ```bash
 packaging/macos/build_dmg.sh
 ```
 
-The output is `dist/macos/AIpet-Murasame.dmg`. Local builds are ad-hoc signed;
-public distribution still requires an Apple Developer ID and notarization.
+The output is `dist/macos/AIpet-Murasame.dmg`. The pinned GPT-SoVITS source
+download is cached after the first build and verified against its recorded
+checksum, so rebuilds skip the network. Local builds are ad-hoc signed; public
+distribution still requires an Apple Developer ID and notarization.

--- a/packaging/macos/AIpet-macOS.spec
+++ b/packaging/macos/AIpet-macOS.spec
@@ -12,6 +12,8 @@ uv_path = Path(os.environ["AIPET_MACOS_UV"])
 overlay_path = Path(os.environ["AIPET_MACOS_FULLSCREEN_OVERLAY"])
 gpt_sovits_source = Path(os.environ["AIPET_MACOS_GPT_SOVITS_SOURCE"])
 gpt_sovits_checksum = Path(os.environ["AIPET_MACOS_GPT_SOVITS_CHECKSUM"])
+app_version = os.environ.get("AIPET_MACOS_VERSION", "2.0.4-macos.1")
+short_version = app_version.split("-", 1)[0]
 
 datas = [
     (str(project_root / "fgimages"), "fgimages"),
@@ -93,6 +95,8 @@ app = BUNDLE(
     bundle_identifier="com.aipet.murasame",
     info_plist={
         "CFBundleDisplayName": "AIpet-Murasame",
+        "CFBundleShortVersionString": short_version,
+        "CFBundleVersion": app_version,
         "LSMinimumSystemVersion": "13.0",
         "NSHighResolutionCapable": True,
         "NSMicrophoneUsageDescription": (

--- a/packaging/macos/AIpet-macOS.spec
+++ b/packaging/macos/AIpet-macOS.spec
@@ -12,7 +12,7 @@ uv_path = Path(os.environ["AIPET_MACOS_UV"])
 overlay_path = Path(os.environ["AIPET_MACOS_FULLSCREEN_OVERLAY"])
 gpt_sovits_source = Path(os.environ["AIPET_MACOS_GPT_SOVITS_SOURCE"])
 gpt_sovits_checksum = Path(os.environ["AIPET_MACOS_GPT_SOVITS_CHECKSUM"])
-app_version = os.environ.get("AIPET_MACOS_VERSION", "2.0.4-macos.1")
+app_version = os.environ["AIPET_MACOS_VERSION"]
 short_version = app_version.split("-", 1)[0]
 
 datas = [

--- a/packaging/macos/build_dmg.sh
+++ b/packaging/macos/build_dmg.sh
@@ -57,7 +57,10 @@ clang -framework Cocoa -framework CoreGraphics \
   "$project_root/aipet/platforms/macos/fullscreen_overlay.m" \
   -o "$overlay_binary"
 export AIPET_MACOS_FULLSCREEN_OVERLAY="$overlay_binary"
-export AIPET_MACOS_VERSION=${AIPET_MACOS_VERSION:-"2.0.4-macos.1"}
+# Release builds should pass AIPET_MACOS_VERSION explicitly. Keep local
+# development builds clearly distinguishable instead of silently reusing a
+# stale release version.
+export AIPET_MACOS_VERSION=${AIPET_MACOS_VERSION:-"0.0.0"}
 "$venv_root/bin/python" -m PyInstaller \
   --noconfirm \
   --clean \

--- a/packaging/macos/build_dmg.sh
+++ b/packaging/macos/build_dmg.sh
@@ -31,11 +31,25 @@ export AIPET_MACOS_ICON="$icon_file"
 export AIPET_MACOS_UV="$venv_root/bin/uv"
 gpt_sovits_source="$build_root/gpt-sovits-source.zip"
 gpt_sovits_checksum="$build_root/gpt-sovits-source.sha256"
-curl --fail --location --retry 3 \
-  --output "$gpt_sovits_source.partial" \
-  "https://github.com/RVC-Boss/GPT-SoVITS/archive/d7c2210da8c013e81a94bfc7b811a477c99fd506.zip"
-mv "$gpt_sovits_source.partial" "$gpt_sovits_source"
-shasum -a 256 "$gpt_sovits_source" > "$gpt_sovits_checksum"
+gpt_sovits_commit="d7c2210da8c013e81a94bfc7b811a477c99fd506"
+
+# Reuse a previously verified download when the cached archive still matches
+# its recorded checksum; otherwise fetch the pinned source. The codeload
+# endpoint is tried first because the github.com archive redirect is blocked
+# on some networks, with the standard archive URL kept as a fallback.
+if [[ -f "$gpt_sovits_source" && -f "$gpt_sovits_checksum" ]] \
+  && [[ "$(cat "$gpt_sovits_checksum")" == "$(shasum -a 256 "$gpt_sovits_source")" ]]; then
+  echo "Reusing verified cached GPT-SoVITS source: $gpt_sovits_source"
+else
+  curl --fail --location --retry 3 --connect-timeout 15 --max-time 900 \
+    --output "$gpt_sovits_source.partial" \
+    "https://codeload.github.com/RVC-Boss/GPT-SoVITS/zip/$gpt_sovits_commit" \
+    || curl --fail --location --retry 3 --connect-timeout 15 --max-time 900 \
+      --output "$gpt_sovits_source.partial" \
+      "https://github.com/RVC-Boss/GPT-SoVITS/archive/$gpt_sovits_commit.zip"
+  mv "$gpt_sovits_source.partial" "$gpt_sovits_source"
+  shasum -a 256 "$gpt_sovits_source" > "$gpt_sovits_checksum"
+fi
 export AIPET_MACOS_GPT_SOVITS_SOURCE="$gpt_sovits_source"
 export AIPET_MACOS_GPT_SOVITS_CHECKSUM="$gpt_sovits_checksum"
 overlay_binary="$build_root/aipet-fullscreen-overlay"
@@ -43,6 +57,7 @@ clang -framework Cocoa -framework CoreGraphics \
   "$project_root/aipet/platforms/macos/fullscreen_overlay.m" \
   -o "$overlay_binary"
 export AIPET_MACOS_FULLSCREEN_OVERLAY="$overlay_binary"
+export AIPET_MACOS_VERSION=${AIPET_MACOS_VERSION:-"2.0.4-macos.1"}
 "$venv_root/bin/python" -m PyInstaller \
   --noconfirm \
   --clean \

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ctypes
 import json
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -135,6 +136,11 @@ class CoreTests(unittest.TestCase):
                     )
                 )
 
+    @unittest.skipUnless(
+        sys.platform == "win32",
+        "The preferred-endpoint filter is exercised with Windows host-API "
+        "names (MME/WASAPI/DirectSound)",
+    )
     def test_audio_input_devices_prefer_supported_user_endpoints(self) -> None:
         devices = [
             AudioInputDevice(
@@ -489,6 +495,11 @@ class CoreTests(unittest.TestCase):
         self.assertEqual(migrated.vision.aliyun_model, "legacy-vl")
         self.assertEqual(migrated.vision.timeout_seconds, 90)
 
+    @unittest.skipUnless(
+        sys.platform == "win32",
+        "Legacy managed-TTS paths are a Windows LOCALAPPDATA concept; the "
+        "macOS runtime has no legacy managed TTS root",
+    )
     def test_legacy_managed_tts_paths_move_to_project_models(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/tests/test_download_manager.py
+++ b/tests/test_download_manager.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import http.server
 import subprocess
+import sys
 import tempfile
 import threading
 import unittest
@@ -39,6 +40,10 @@ class _QuietHandler(http.server.SimpleHTTPRequestHandler):
 
 
 class DownloadWorkerTests(unittest.TestCase):
+    @unittest.skipUnless(
+        sys.platform == "win32",
+        "Managed GPT-SoVITS engine downloads are a Windows-EXE capability",
+    )
     def test_manager_uses_explicit_download_destinations(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -86,6 +91,10 @@ class DownloadWorkerTests(unittest.TestCase):
             ):
                 self.assertEqual(_find_7zip(), executable.resolve())
 
+    @unittest.skipUnless(
+        sys.platform == "win32",
+        "A bundled 7-Zip is only shipped inside the Windows build",
+    )
     def test_prefers_bundled_7zip(self) -> None:
         self.assertTrue(BUNDLED_7ZIP.is_file())
         with patch(
@@ -138,6 +147,10 @@ class DownloadWorkerTests(unittest.TestCase):
                 any(root.glob(".GPT-SoVITS-backup-*"))
             )
 
+    @unittest.skipUnless(
+        sys.platform == "win32",
+        "Managed GPT-SoVITS engine archives are a Windows-EXE capability",
+    )
     def test_selects_engine_archive_for_gpu_generation(self) -> None:
         self.assertEqual(
             select_tts_engine_archive(["NVIDIA GeForce RTX 5070 Ti"]),
@@ -158,6 +171,10 @@ class DownloadWorkerTests(unittest.TestCase):
             TTS_ENGINE_ARCHIVE,
         )
 
+    @unittest.skipUnless(
+        sys.platform == "win32",
+        "Managed GPT-SoVITS engine archives are a Windows-EXE capability",
+    )
     def test_tts_download_includes_selected_engine_archive(self) -> None:
         with patch(
             "aipet.core.download_manager.detect_nvidia_gpu_names",
@@ -175,6 +192,10 @@ class DownloadWorkerTests(unittest.TestCase):
         )
         self.assertGreater(archives[0].size, 8_000_000_000)
 
+    @unittest.skipUnless(
+        sys.platform == "win32",
+        "Managed GPT-SoVITS engine archives are a Windows-EXE capability",
+    )
     def test_extracts_nested_gpt_sovits_engine(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/tests/test_runtime_logging.py
+++ b/tests/test_runtime_logging.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import logging
+import sys
 import tempfile
 import unittest
 from contextlib import redirect_stdout
@@ -87,6 +88,10 @@ class RuntimeLoggingTests(unittest.TestCase):
             self.assertIn("existing", output.getvalue())
             self.assertIn("live update", output.getvalue())
 
+    @unittest.skipUnless(
+        sys.platform == "win32",
+        "Windows console allocation is not part of the macOS adapter",
+    )
     def test_viewer_allocates_console_before_opening_output(self) -> None:
         kernel32 = MagicMock()
         kernel32.GetConsoleWindow.return_value = 0
@@ -153,6 +158,10 @@ class RuntimeLoggingTests(unittest.TestCase):
         self.assertNotIn("do-not-log-this", output)
         self.assertNotIn("encrypted-password-token", output)
 
+    @unittest.skipUnless(
+        sys.platform == "win32",
+        "pythonw.exe resolution is a Windows-only log-viewer concern",
+    )
     def test_console_viewer_uses_python_instead_of_pythonw(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -170,6 +179,10 @@ class RuntimeLoggingTests(unittest.TestCase):
                 str(python),
             )
 
+    @unittest.skipUnless(
+        sys.platform == "win32",
+        "The console log viewer is a Windows-only feature",
+    )
     def test_source_viewer_command_runs_log_viewer_script(self) -> None:
         with (
             patch.object(runtime_logging.sys, "executable", "python.exe"),
@@ -192,6 +205,10 @@ class RuntimeLoggingTests(unittest.TestCase):
             ],
         )
 
+    @unittest.skipUnless(
+        sys.platform == "win32",
+        "The console log viewer is a Windows-only feature",
+    )
     def test_frozen_viewer_command_reuses_exe_special_mode(self) -> None:
         with (
             patch.object(runtime_logging.sys, "executable", "AIpet.exe"),
@@ -209,6 +226,10 @@ class RuntimeLoggingTests(unittest.TestCase):
             ["AIpet.exe", "--log-viewer", "C:\\logs", "123"],
         )
 
+    @unittest.skipUnless(
+        sys.platform == "win32",
+        "The console log viewer is a Windows-only feature",
+    )
     def test_main_dispatches_log_viewer_special_mode(self) -> None:
         with patch("aipet.platforms.windows.log_viewer.follow") as follow:
             result = run_special_mode(

--- a/tests/test_tts_service.py
+++ b/tests/test_tts_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -17,6 +18,11 @@ from aipet.core.tts_service import (
 
 
 class TTSServiceTests(unittest.TestCase):
+    @unittest.skipUnless(
+        sys.platform == "win32",
+        "A bundled runtime/python.exe layout only exists in the Windows "
+        "build; the macOS adapter installs an isolated .venv instead",
+    )
     def test_build_command_prefers_bundled_runtime(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             engine = self._create_engine(Path(directory))
@@ -50,6 +56,11 @@ class TTSServiceTests(unittest.TestCase):
             ):
                 _build_start_command(engine, ("127.0.0.1", 9880))
 
+    @unittest.skipUnless(
+        sys.platform == "win32",
+        "A bundled runtime/python.exe layout only exists in the Windows "
+        "build; the macOS adapter installs an isolated .venv instead",
+    )
     def test_ensure_running_launches_once_and_stop_only_owned_process(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- sync the reviewed macOS V2.0.4 packaging changes from `fsh114514/AIpet-Murasame-macOS`
- add DMG installation and Gatekeeper guidance
- set macOS bundle version metadata during packaging
- improve GPT-SoVITS source download fallback and verified cache reuse
- skip Windows-only tests on non-Windows platforms
- avoid silently reusing a stale release version in future local macOS builds

## Why

The macOS V2.0.4 DMG is ready to be attached to the existing upstream release. Keeping the corresponding packaging code in the upstream repository makes future macOS builds maintainable and documents how the published artifact was produced.

The contributor's original commit and authorship are preserved in commit `293d19e`.

## Validation

- `bash -n packaging/macos/build_dmg.sh`
- `python -m py_compile packaging/macos/AIpet-macOS.spec`
- `python -m compileall -q aipet tests packaging/macos/AIpet-macOS.spec`
- `git diff --check origin/developing...HEAD`
- reviewed the full 7-file patch against upstream V2.0.4
- downloaded and inspected the published Apple Silicon DMG; SHA-256 matches `604c5138c9c1303b2bf4440e27977044fb7b024a3b828ab382ef7f273ec6df9e`

The full unit suite could not run in the current Linux environment because AIpet has no Linux platform adapter and the environment could not install the optional GUI/runtime dependencies. The macOS build maintainer reports 131 tests passing on macOS.