### PR TITLE
Restore direct downloads and show transfer speed

### DIFF
--- a/aipet/core/download_manager.py
+++ b/aipet/core/download_manager.py
@@ -10,6 +10,7 @@ import re
 import shutil
 import subprocess
 import threading
+import time
 import uuid
 from collections import deque
 from dataclasses import dataclass
@@ -18,7 +19,6 @@ from typing import Callable
 from urllib.parse import quote
 
 import requests
-from modelscope_hub import HubApi
 from PyQt5.QtCore import QObject, QThread, pyqtSignal
 
 from aipet.core.config import PROJECT_ROOT
@@ -34,8 +34,10 @@ TTS_JOB_ID = "tts:murasame"
 TTS_MODEL_NAME = "Murasame_SoVITS"
 TTS_WEIGHTS_MODEL = "LemonQu/Murasame_SoVITS"
 TTS_REFERENCE_MODEL = "kuxiaowo/Murasame-tts-reference-voice"
+MODELSCOPE_ENDPOINT = "https://www.modelscope.cn/models"
 HUGGING_FACE_ENDPOINT = "https://huggingface.co"
 HUGGING_FACE_MIRROR_ENDPOINT = "https://hf-mirror.com"
+DOWNLOAD_SPEED_WINDOW_SECONDS = 3.0
 _PLATFORM_TTS_ARCHIVES = tuple(
     get_platform_runtime().archives.tts_engine_archives()
 )
@@ -71,21 +73,12 @@ BUNDLED_7ZIP = (
 
 
 @dataclass(frozen=True)
-class ModelScopeSource:
-    repository: str
-    file_path: str
-    local_subdirectory: str = ""
-    revision: str = "master"
-
-
-@dataclass(frozen=True)
 class RemoteFile:
     url: str
     relative_path: str
     size: int
     sha256: str = ""
     fallback_urls: tuple[str, ...] = ()
-    modelscope: ModelScopeSource | None = None
 
 
 @dataclass(frozen=True)
@@ -96,6 +89,7 @@ class DownloadSnapshot:
     current_file: str = ""
     message: str = ""
     destination: str = ""
+    speed_bps: float = 0.0
 
 
 class AssetDownloadWorker(QThread):
@@ -126,7 +120,6 @@ class AssetDownloadWorker(QThread):
         self.include_tts_engine = include_tts_engine
         self.tts_engine_destination = tts_engine_destination
         self._cancelled = threading.Event()
-        self._modelscope_api: HubApi | None = None
 
     def cancel(self) -> None:
         self._cancelled.set()
@@ -250,13 +243,6 @@ class AssetDownloadWorker(QThread):
         completed_before: int,
         total: int,
     ) -> int:
-        if item.modelscope is not None:
-            return self._download_modelscope_file(
-                item,
-                completed_before,
-                total,
-            )
-
         errors: list[Exception] = []
         urls = (item.url, *item.fallback_urls)
         for index, url in enumerate(urls):
@@ -349,105 +335,6 @@ class AssetDownloadWorker(QThread):
         os.replace(partial, target)
         return completed_before + item.size
 
-    def _download_modelscope_file(
-        self,
-        item: RemoteFile,
-        completed_before: int,
-        total: int,
-    ) -> int:
-        source = item.modelscope
-        if source is None:
-            raise RuntimeError("ModelScope download source was not provided")
-
-        target = self.destination / item.relative_path
-        local_dir = self.destination / source.local_subdirectory
-        sdk_target = local_dir / Path(source.file_path)
-        if sdk_target.resolve() != target.resolve():
-            raise RuntimeError(
-                f"ModelScope target mismatch for {item.relative_path}"
-            )
-        target.parent.mkdir(parents=True, exist_ok=True)
-
-        partial = target.with_name(target.name + ".part")
-        sdk_partial = target.with_suffix(target.suffix + ".incomplete")
-        if sdk_partial.exists() and sdk_partial.stat().st_size > item.size:
-            sdk_partial.unlink()
-        if partial.exists():
-            if partial.stat().st_size > item.size:
-                partial.unlink()
-            elif sdk_partial.exists():
-                if partial.stat().st_size > sdk_partial.stat().st_size:
-                    sdk_partial.unlink()
-                    os.replace(partial, sdk_partial)
-                else:
-                    partial.unlink()
-            else:
-                os.replace(partial, sdk_partial)
-
-        if self._modelscope_api is None:
-            self._modelscope_api = HubApi()
-        monitor_finished = threading.Event()
-
-        def monitor_progress() -> None:
-            while not monitor_finished.wait(0.1):
-                try:
-                    downloaded = sdk_partial.stat().st_size
-                except OSError:
-                    continue
-                self.progress.emit(
-                    self.job_id,
-                    completed_before + min(downloaded, item.size),
-                    total,
-                    item.relative_path,
-                )
-
-        monitor = threading.Thread(
-            target=monitor_progress,
-            name="modelscope-download-progress",
-            daemon=True,
-        )
-        monitor.start()
-        try:
-            self._modelscope_api.download_file(
-                repo_id=source.repository,
-                repo_type="model",
-                file_path=source.file_path,
-                revision=source.revision,
-                local_dir=local_dir,
-                expected_sha256=item.sha256 or None,
-            )
-        except Exception:
-            if sdk_partial.exists():
-                os.replace(sdk_partial, partial)
-            raise
-        finally:
-            monitor_finished.set()
-            monitor.join(timeout=1)
-
-        if not target.is_file() or target.stat().st_size != item.size:
-            if target.exists():
-                os.replace(target, partial)
-            received = partial.stat().st_size if partial.exists() else 0
-            raise RuntimeError(
-                f"{item.relative_path}: expected {item.size} bytes, "
-                f"received {received}"
-            )
-        if item.sha256 and self._verified_sha256(
-            target,
-            item,
-        ) != item.sha256.lower():
-            target.unlink(missing_ok=True)
-            raise RuntimeError(
-                f"{item.relative_path}: SHA-256 verification failed"
-            )
-        self.progress.emit(
-            self.job_id,
-            completed_before + item.size,
-            total,
-            item.relative_path,
-        )
-        return completed_before + item.size
-
     def _verified_sha256(
         self,
         path: Path,
@@ -521,6 +408,10 @@ class DownloadManager(QObject):
         )
         self._workers: dict[str, AssetDownloadWorker] = {}
         self._snapshots: dict[str, DownloadSnapshot] = {}
+        self._speed_samples: dict[
+            str,
+            deque[tuple[float, int]],
+        ] = {}
 
     def snapshot(self, job_id: str) -> DownloadSnapshot:
         return self._snapshots.get(job_id, DownloadSnapshot())
@@ -587,6 +478,7 @@ class DownloadManager(QObject):
             parent=self,
         )
         self._workers[job_id] = worker
+        self._speed_samples.pop(job_id, None)
         self._publish(
             job_id,
             DownloadSnapshot(
@@ -634,6 +526,30 @@ class DownloadManager(QObject):
             ),
         )
 
+    def _download_speed(
+        self,
+        job_id: str,
+        received: int,
+        previous: DownloadSnapshot,
+    ) -> float:
+        now = time.monotonic()
+        samples = self._speed_samples.setdefault(job_id, deque())
+        if previous.status != "downloading" or received < previous.received:
+            samples.clear()
+            samples.append((now, received))
+            return 0.0
+        if not samples:
+            samples.append((now, previous.received))
+        samples.append((now, received))
+        cutoff = now - DOWNLOAD_SPEED_WINDOW_SECONDS
+        while len(samples) > 2 and samples[0][0] < cutoff:
+            samples.popleft()
+        started_at, started_bytes = samples[0]
+        elapsed = now - started_at
+        if elapsed <= 0:
+            return previous.speed_bps
+        return max(received - started_bytes, 0) / elapsed
+
     def _on_progress(
         self,
         job_id: str,
@@ -642,6 +558,7 @@ class DownloadManager(QObject):
         current_file: str,
     ) -> None:
         current = self.snapshot(job_id)
+        speed_bps = self._download_speed(job_id, received, current)
         self._publish(
             job_id,
             DownloadSnapshot(
@@ -650,6 +567,7 @@ class DownloadManager(QObject):
                 total=total,
                 current_file=current_file,
                 destination=current.destination,
+                speed_bps=speed_bps,
             ),
         )
 
@@ -694,6 +612,7 @@ class DownloadManager(QObject):
 
     def _on_completed(self, job_id: str, destination: str) -> None:
         current = self.snapshot(job_id)
+        self._speed_samples.pop(job_id, None)
         self._publish(
             job_id,
             DownloadSnapshot(
@@ -706,6 +625,7 @@ class DownloadManager(QObject):
 
     def _on_failed(self, job_id: str, message: str) -> None:
         current = self.snapshot(job_id)
+        self._speed_samples.pop(job_id, None)
         self._publish(
             job_id,
             DownloadSnapshot(
@@ -725,6 +645,7 @@ class DownloadManager(QObject):
     ) -> None:
         if self._workers.get(job_id) is worker:
             self._workers.pop(job_id, None)
+        self._speed_samples.pop(job_id, None)
         worker.deleteLater()
 
     def _publish(self, job_id: str, snapshot: DownloadSnapshot) -> None:
@@ -761,32 +682,42 @@ def whisper_job_id(repository: str) -> str:
     return f"whisper:{repository}"
 
 
+def _modelscope_url(
+    repository: str,
+    file_path: str,
+    revision: str = "master",
+) -> str:
+    return (
+        f"{MODELSCOPE_ENDPOINT}/{quote(repository, safe='/')}"
+        f"/resolve/{quote(revision, safe='')}/"
+        f"{quote(file_path, safe='/')}"
+    )
+
+
 def _tts_files(*, include_engine: bool = False) -> list[RemoteFile]:
     files = [
         RemoteFile(
-            url="",
+            url=_modelscope_url(
+                TTS_WEIGHTS_MODEL,
+                "murasame-gpt.ckpt",
+            ),
             relative_path="murasame-gpt.ckpt",
             size=155_312_594,
             sha256=(
                 "a0d6df8a0acda9efddbe0ce47e4317f2"
                 "991cc9a46233cb8ab8d86744c568e85d"
             ),
-            modelscope=ModelScopeSource(
-                TTS_WEIGHTS_MODEL,
-                "murasame-gpt.ckpt",
-            ),
         ),
         RemoteFile(
-            url="",
+            url=_modelscope_url(
+                TTS_WEIGHTS_MODEL,
+                "murasame-sovits.pth",
+            ),
             relative_path="murasame-sovits.pth",
             size=75_550_062,
             sha256=(
                 "2518d5ddb54ada45dad70a3ed3c27c70"
                 "d2f9655e1d0dad5c8e81af2d7f3972c6"
-            ),
-            modelscope=ModelScopeSource(
-                TTS_WEIGHTS_MODEL,
-                "murasame-sovits.pth",
             ),
         ),
     ]
@@ -854,14 +785,13 @@ def _tts_files(*, include_engine: bool = False) -> list[RemoteFile]:
     )
     files.extend(
         RemoteFile(
-            url="",
-            relative_path=f"reference_voices/{relative_path}",
-            size=size,
-            sha256=sha256,
-            modelscope=ModelScopeSource(
+            url=_modelscope_url(
                 TTS_REFERENCE_MODEL,
                 f"reference_voices/{relative_path}",
             ),
+            relative_path=f"reference_voices/{relative_path}",
+            size=size,
+            sha256=sha256,
         )
         for relative_path, size, sha256 in reference_files
     )
@@ -871,15 +801,13 @@ def _tts_files(*, include_engine: bool = False) -> list[RemoteFile]:
         )
         files.append(
             RemoteFile(
-                url="",
+                url=_modelscope_url(
+                    archive.repository,
+                    archive.filename,
+                ),
                 relative_path=f".downloads/{archive.filename}",
                 size=archive.size,
                 sha256=archive.sha256,
-                modelscope=ModelScopeSource(
-                    archive.repository,
-                    archive.filename,
-                    local_subdirectory=".downloads",
-                ),
             )
         )
     return files

--- a/aipet/ui/settings_dialog.py
+++ b/aipet/ui/settings_dialog.py
@@ -2958,6 +2958,8 @@ class SettingsDialog(QDialog):
             f"{percent:.1f}% · {self._format_bytes(snapshot.received)} / "
             f"{self._format_bytes(snapshot.total)}"
         )
+        if snapshot.status == "downloading":
+            detail += f" · {self._format_bytes(snapshot.speed_bps)}/s"
         if snapshot.current_file:
             detail += f" · {Path(snapshot.current_file).name}"
         return detail
@@ -2991,7 +2993,7 @@ class SettingsDialog(QDialog):
         return detail
 
     @staticmethod
-    def _format_bytes(value: int) -> str:
+    def _format_bytes(value: int | float) -> str:
         size = float(value)
         for unit in ("B", "KB", "MB", "GB", "TB"):
             if size < 1024 or unit == "TB":

--- a/packaging/check_build_environment.py
+++ b/packaging/check_build_environment.py
@@ -11,7 +11,6 @@ REQUIRED_MODULES = (
     "ctranslate2",
     "cv2",
     "faster_whisper",
-    "modelscope_hub",
     "numpy",
     "onnxruntime",
     "paramiko",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ pydantic>=2.11,<3
 PyQt5>=5.15.11,<6
 paramiko>=3.5,<5
 requests>=2.32,<3
-modelscope-hub>=0.1.8,<0.2

--- a/tests/test_download_manager.py
+++ b/tests/test_download_manager.py
@@ -16,17 +16,19 @@ from aipet.core.download_manager import (
     BUNDLED_7ZIP,
     HUGGING_FACE_ENDPOINT,
     HUGGING_FACE_MIRROR_ENDPOINT,
+    MODELSCOPE_ENDPOINT,
     TTS_ENGINE_ARCHIVE,
     TTS_ENGINE_ARCHIVE_NVIDIA50,
     TTS_REFERENCE_MODEL,
     TTS_WEIGHTS_MODEL,
     AssetDownloadWorker,
     DownloadManager,
-    ModelScopeSource,
+    DownloadSnapshot,
     RemoteFile,
     _activate_extracted_engine,
     _extract_gpt_sovits_archive,
     _find_7zip,
+    _modelscope_url,
     _sha256,
     _tts_files,
     _whisper_files,
@@ -113,6 +115,27 @@ class DownloadWorkerTests(unittest.TestCase):
 
             self.assertTrue(progress)
             self.assertEqual(progress[-1], path.stat().st_size)
+
+    def test_manager_calculates_download_speed_from_recent_progress(
+        self,
+    ) -> None:
+        manager = DownloadManager()
+        manager._snapshots["test"] = DownloadSnapshot(
+            status="checking",
+            received=100,
+            total=10_000,
+        )
+        with patch(
+            "aipet.core.download_manager.time.monotonic",
+            side_effect=[10.0, 11.0, 12.0],
+        ):
+            manager._on_progress("test", 100, 10_000, "model.bin")
+            manager._on_progress("test", 1_124, 10_000, "model.bin")
+            manager._on_progress("test", 3_172, 10_000, "model.bin")
+
+        snapshot = manager.snapshot("test")
+        self.assertEqual(snapshot.status, "downloading")
+        self.assertEqual(snapshot.speed_bps, 1_536.0)
 
     def test_atomically_replaces_managed_engine(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -260,16 +283,18 @@ class DownloadWorkerTests(unittest.TestCase):
         self.assertEqual(len(weights), 2)
         self.assertTrue(
             all(
-                item.modelscope is not None
-                and item.modelscope.repository == TTS_WEIGHTS_MODEL
+                item.url.startswith(
+                    f"{MODELSCOPE_ENDPOINT}/{TTS_WEIGHTS_MODEL}/"
+                )
                 for item in weights
             )
         )
         self.assertEqual(len(references), 12)
         self.assertTrue(
             all(
-                item.modelscope is not None
-                and item.modelscope.repository == TTS_REFERENCE_MODEL
+                item.url.startswith(
+                    f"{MODELSCOPE_ENDPOINT}/{TTS_REFERENCE_MODEL}/"
+                )
                 for item in references
             )
         )
@@ -282,6 +307,12 @@ class DownloadWorkerTests(unittest.TestCase):
         self.assertEqual(
             happy.sha256,
             "aed4a6391ee7241a70556559588beb2b03171ab9dc1afca317d04dc5f98be83c",
+        )
+        self.assertEqual(
+            happy.url,
+            f"{MODELSCOPE_ENDPOINT}/{TTS_REFERENCE_MODEL}"
+            "/resolve/master/reference_voices/"
+            "%E9%AB%98%E5%85%B4/ref.mp3",
         )
 
     def test_same_size_file_with_wrong_hash_is_not_complete(self) -> None:
@@ -305,58 +336,15 @@ class DownloadWorkerTests(unittest.TestCase):
 
             self.assertFalse(worker._target_is_complete(item))
 
-    def test_modelscope_downloads_one_file_and_resumes_legacy_part(self) -> None:
-        payload = b"modelscope-hub single file"
-        with tempfile.TemporaryDirectory() as directory:
-            destination = Path(directory)
-            partial = destination / "nested" / "model.bin.part"
-            partial.parent.mkdir(parents=True)
-            partial.write_bytes(payload[:7])
-            item = RemoteFile(
-                url="",
-                relative_path="nested/model.bin",
-                size=len(payload),
-                sha256=hashlib.sha256(payload).hexdigest(),
-                modelscope=ModelScopeSource(
-                    "owner/repository",
-                    "nested/model.bin",
-                ),
-            )
-            worker = AssetDownloadWorker(
-                "test",
-                "tts",
-                "test/model",
-                destination,
-            )
-            api = Mock()
-
-            def download_file(**kwargs) -> None:
-                target = Path(kwargs["local_dir"]) / kwargs["file_path"]
-                incomplete = target.with_suffix(
-                    target.suffix + ".incomplete"
-                )
-                self.assertEqual(incomplete.read_bytes(), payload[:7])
-                with incomplete.open("ab") as output:
-                    output.write(payload[7:])
-                incomplete.replace(target)
-
-            api.download_file.side_effect = download_file
-            worker._modelscope_api = api
-
-            received = worker._download_file(item, 0, len(payload))
-
-            self.assertEqual(received, len(payload))
-            self.assertEqual(
-                (destination / "nested" / "model.bin").read_bytes(),
-                payload,
-            )
-            self.assertFalse(partial.exists())
-            api.download_file.assert_called_once()
-            call = api.download_file.call_args.kwargs
-            self.assertEqual(call["repo_id"], "owner/repository")
-            self.assertEqual(call["file_path"], "nested/model.bin")
-            self.assertEqual(call["revision"], "master")
-            self.assertEqual(call["expected_sha256"], item.sha256)
+    def test_modelscope_url_quotes_unicode_file_paths(self) -> None:
+        self.assertEqual(
+            _modelscope_url(
+                "owner/repository",
+                "reference_voices/平静/ref.wav",
+            ),
+            f"{MODELSCOPE_ENDPOINT}/owner/repository/resolve/master/"
+            "reference_voices/%E5%B9%B3%E9%9D%99/ref.wav",
+        )
 
     def test_whisper_metadata_and_files_fall_back_to_hf_mirror(self) -> None:
         metadata = Mock()

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -851,6 +851,7 @@ class UISmokeTests(unittest.TestCase):
                     received=50,
                     total=100,
                     current_file="model.bin",
+                    speed_bps=1024 * 1024,
                 )
                 dialog._on_download_changed(
                     whisper_job_id(model_repository("large-v3")),
@@ -858,6 +859,7 @@ class UISmokeTests(unittest.TestCase):
                 )
                 self.assertFalse(dialog.whisper_progress.isHidden())
                 self.assertEqual(dialog.whisper_progress.value(), 500)
+                self.assertIn("1.0 MB/s", dialog.whisper_status.text())
                 (Path(directory) / "model.bin").write_bytes(b"model")
                 (Path(directory) / "config.json").write_text(
                     "{}",


### PR DESCRIPTION
## What changed

- restore ModelScope downloads to the previous encoded `/resolve/master/...` URL construction
- remove the `modelscope-hub` runtime and packaging dependency
- retain HTTP resume, fallback, size validation, and SHA-256 verification
- calculate transfer speed over a recent rolling window and display it for TTS and Whisper downloads
- update download and UI tests for direct URLs and visible speed

## Why

The SDK path could complete requests without giving users useful real-time feedback and introduced an extra dependency. Returning to the known direct-download path makes progress observable and keeps the downloader simpler.

## Validation

- `python -m unittest tests.test_download_manager -v` — 15 passed
- `python -m unittest tests.test_ui_smoke.UISmokeTests.test_settings_dialog_and_pet_construct -v` — passed
- `python -m unittest tests.test_voice_trigger tests.test_whisper_models -v` — passed (platform-only voice tests skipped as expected)
- real direct download of the 247,860-byte reference WAV — size and SHA-256 verified, temporary files cleaned
- Range probes for all 14 TTS weight/reference URLs — 14/14 accessible with expected remote sizes
- `python -m compileall -q aipet tests`, `python -m pip check`, and `git diff --check` — passed

## Existing baseline failures

The full discovery run still encounters two unrelated tests that fail identically on untouched `origin/main` (`test_api_chat_uses_selected_provider_and_json_mode` and `test_disabled_screen_vision_is_inert`). The Windows Qt smoke process also exits with an access violation after reaching the same baseline area; the download-specific UI smoke test passes independently.