### PR TITLE
Release V2.0.5

### DIFF
--- a/aipet/__init__.py
+++ b/aipet/__init__.py
@@ -4,4 +4,4 @@ from __future__ import annotations
 
 __all__ = ["__version__"]
 
-__version__ = "2.0.1"
+__version__ = "2.0.5"


### PR DESCRIPTION
## 变更

- 将应用版本号更新为 `2.0.5`
- 以已合并的直连下载修复 `f8134c2` 作为发布基线

## 原因与影响

V2.0.4 Windows 无控制台构建中，`modelscope-hub` 的进度输出会访问空的 `sys.stderr`，导致模型下载被包装成重试失败。当前 `main` 已恢复基于 `requests` 的 ModelScope 单文件直连下载，并保留断点续传、大小检查和 SHA-256 校验。

## 验证

- 全量测试：147 项通过，3 项跳过
- 真实下载全部 14 个丛雨角色模型文件：231,361,087 字节，大小与 SHA-256 全部通过
- Windows 标准版和 CUDA 版构建成功
- 两个 EXE 的内置 7-Zip 校验通过
- macOS V2.0.5 DMG SHA-256 已与维护者 Release 复核一致