### PR TITLE
Safeguard TTS download directories

### DIFF
--- a/aipet/core/config.py
+++ b/aipet/core/config.py
@@ -17,6 +17,8 @@ from aipet.platforms import get_platform_runtime
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 APP_DIRECTORY_NAME = "AIpet-Murasame"
+TTS_ENGINE_DIRECTORY_NAME = "GPT-SoVITS"
+TTS_MODEL_DIRECTORY_NAME = "Murasame_SoVITS"
 
 
 def get_user_data_dir() -> Path:
@@ -55,12 +57,24 @@ def get_default_download_root() -> Path:
     )
 
 
+def default_tts_storage_root() -> str:
+    return str(get_default_download_root() / "tts")
+
+
+def tts_paths_for_storage_root(root: str | Path) -> tuple[Path, Path]:
+    storage_root = Path(root).expanduser()
+    return (
+        storage_root / TTS_ENGINE_DIRECTORY_NAME,
+        storage_root / TTS_MODEL_DIRECTORY_NAME,
+    )
+
+
 def default_tts_engine_root() -> str:
-    return str(get_default_download_root() / "tts" / "GPT-SoVITS")
+    return str(tts_paths_for_storage_root(default_tts_storage_root())[0])
 
 
 def default_tts_model_dir() -> str:
-    return str(get_default_download_root() / "tts" / "Murasame_SoVITS")
+    return str(tts_paths_for_storage_root(default_tts_storage_root())[1])
 
 
 def default_whisper_model_dir(model_name: str = "large-v3") -> str:
@@ -213,6 +227,8 @@ class TTSSettings(BaseModel):
         default="http://127.0.0.1:9880/tts",
         min_length=1,
     )
+    storage_root: str = Field(default_factory=default_tts_storage_root)
+    advanced_paths: bool = False
     engine_root: str = Field(default_factory=default_tts_engine_root)
     model_dir: str = Field(default_factory=default_tts_model_dir)
     autodl_ssh_command: str = ""
@@ -221,12 +237,48 @@ class TTSSettings(BaseModel):
     autodl_password_encrypted: str = ""
     timeout_seconds: int = Field(default=300, ge=10, le=900)
 
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_exact_paths_to_storage_root(cls, value):
+        if not isinstance(value, dict):
+            return value
+        payload = dict(value)
+        if "storage_root" in payload or "advanced_paths" in payload:
+            return payload
+
+        configured_engine = str(payload.get("engine_root") or "").strip()
+        configured_model = str(payload.get("model_dir") or "").strip()
+        if not configured_engine and not configured_model:
+            return payload
+
+        engine = Path(configured_engine).expanduser()
+        model = Path(configured_model).expanduser()
+        standard_siblings = (
+            engine.name.casefold() == TTS_ENGINE_DIRECTORY_NAME.casefold()
+            and model.name.casefold() == TTS_MODEL_DIRECTORY_NAME.casefold()
+            and _paths_equal(engine.parent, model.parent)
+        )
+        if standard_siblings:
+            payload["storage_root"] = str(engine.parent)
+            payload["advanced_paths"] = False
+        else:
+            payload["storage_root"] = default_tts_storage_root()
+            payload["advanced_paths"] = True
+        return payload
+
     @model_validator(mode="after")
     def fill_default_paths(self) -> "TTSSettings":
-        if not self.engine_root.strip():
-            self.engine_root = default_tts_engine_root()
-        if not self.model_dir.strip():
-            self.model_dir = default_tts_model_dir()
+        if not self.storage_root.strip():
+            self.storage_root = default_tts_storage_root()
+        if not self.advanced_paths:
+            engine, model = tts_paths_for_storage_root(self.storage_root)
+            self.engine_root = str(engine)
+            self.model_dir = str(model)
+        else:
+            if not self.engine_root.strip():
+                self.engine_root = default_tts_engine_root()
+            if not self.model_dir.strip():
+                self.model_dir = default_tts_model_dir()
         return self
 
     def uses_autodl(self) -> bool:
@@ -354,6 +406,16 @@ class AppSettings(BaseModel):
             return self
 
         current_root = get_model_dir() / "tts"
+        if (
+            not self.tts.advanced_paths
+            and _paths_equal(self.tts.storage_root, legacy_root)
+        ):
+            self.tts.storage_root = str(current_root)
+            engine, model = tts_paths_for_storage_root(current_root)
+            self.tts.engine_root = str(engine)
+            self.tts.model_dir = str(model)
+            return self
+
         migrations = (
             (
                 "engine_root",

--- a/aipet/core/download_manager.py
+++ b/aipet/core/download_manager.py
@@ -38,6 +38,7 @@ MODELSCOPE_ENDPOINT = "https://www.modelscope.cn/models"
 HUGGING_FACE_ENDPOINT = "https://huggingface.co"
 HUGGING_FACE_MIRROR_ENDPOINT = "https://hf-mirror.com"
 DOWNLOAD_SPEED_WINDOW_SECONDS = 3.0
+GPT_SOVITS_MANAGED_MARKER = ".aipet-managed-gpt-sovits.json"
 _PLATFORM_TTS_ARCHIVES = tuple(
     get_platform_runtime().archives.tts_engine_archives()
 )
@@ -444,6 +445,18 @@ class DownloadManager(QObject):
         if include_engine and engine_destination is None:
             raise ValueError(
                 "GPT-SoVITS download directory is required"
+            )
+        model_destination = _validate_download_destination(
+            model_destination,
+            "voice model",
+        )
+        if engine_destination is not None:
+            engine_destination = _validate_engine_install_destination(
+                engine_destination
+            )
+            _validate_tts_destinations(
+                model_destination,
+                engine_destination,
             )
         self._start(
             TTS_JOB_ID,
@@ -1004,6 +1017,7 @@ def _activate_extracted_engine(
         Callable[[str, int, int, str], None] | None
     ),
 ) -> None:
+    destination = _validate_engine_install_destination(destination)
     destination.parent.mkdir(parents=True, exist_ok=True)
     backup: Path | None = None
     if destination.exists():
@@ -1029,6 +1043,18 @@ def _activate_extracted_engine(
         os.replace(source, destination)
         if not (destination / "api_v2.py").is_file():
             raise RuntimeError("GPT-SoVITS engine installation failed")
+        (destination / GPT_SOVITS_MANAGED_MARKER).write_text(
+            json.dumps(
+                {
+                    "kind": "gpt-sovits-engine",
+                    "managed_by": "AIpet-Murasame",
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
         if install_callback is not None:
             install_callback(
                 "installing",
@@ -1055,6 +1081,49 @@ def _activate_extracted_engine(
                 "previous installation",
             )
         shutil.rmtree(backup, ignore_errors=True)
+
+
+def _validate_download_destination(path: Path, label: str) -> Path:
+    candidate = Path(path).expanduser()
+    if candidate.is_symlink():
+        raise RuntimeError(f"The {label} directory cannot be a symlink.")
+    resolved = candidate.resolve()
+    if resolved.parent == resolved or not resolved.name:
+        raise RuntimeError(
+            f"The {label} directory cannot be a filesystem root."
+        )
+    if resolved.exists() and not resolved.is_dir():
+        raise RuntimeError(f"The {label} destination is not a directory.")
+    return resolved
+
+
+def _validate_engine_install_destination(path: Path) -> Path:
+    destination = _validate_download_destination(path, "GPT-SoVITS engine")
+    if not destination.exists():
+        return destination
+    contents = tuple(destination.iterdir())
+    if not contents:
+        return destination
+    marker = destination / GPT_SOVITS_MANAGED_MARKER
+    if not marker.is_file():
+        raise RuntimeError(
+            "The GPT-SoVITS destination is not empty and is not marked as "
+            "managed by AIpet. Choose a new empty directory or the existing "
+            "AIpet-managed engine directory."
+        )
+    return destination
+
+
+def _validate_tts_destinations(model: Path, engine: Path) -> None:
+    if (
+        model == engine
+        or model in engine.parents
+        or engine in model.parents
+    ):
+        raise RuntimeError(
+            "The GPT-SoVITS engine and voice model directories must be "
+            "separate and cannot contain each other."
+        )
 
 
 def _extract_with_bsdtar(

--- a/aipet/ui/settings_dialog.py
+++ b/aipet/ui/settings_dialog.py
@@ -57,6 +57,7 @@ from aipet.core.config import (
     VisionSettings,
     get_user_data_dir,
     load_personality,
+    tts_paths_for_storage_root,
 )
 from aipet.core.runtime_logging import get_logger
 from aipet.core.stt_languages import COMMON_WHISPER_LANGUAGES
@@ -169,9 +170,16 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "tts_backend_autodl": "AutoDL cloud",
         "tts_endpoint": "TTS endpoint",
         "tts_timeout": "TTS timeout",
-        "tts_engine_root": "GPT-SoVITS download/install directory",
+        "tts_storage_root": "TTS resource storage location",
+        "tts_storage_preview": (
+            "Automatic directories:\n"
+            "Engine: {engine}\n"
+            "Voice model: {model}"
+        ),
+        "tts_advanced_paths": "Advanced",
+        "tts_engine_root": "Exact GPT-SoVITS installation directory",
         "tts_bootstrap": "Install macOS GPT-SoVITS base environment",
-        "tts_model_dir": "Voice model download directory (includes references)",
+        "tts_model_dir": "Exact voice model directory (includes references)",
         "tts_autodl_ssh_command": "AutoDL SSH login command",
         "tts_autodl_password": "AutoDL SSH password",
         "tts_autodl_remote_command": "Remote TTS start command",
@@ -308,6 +316,9 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "whisper_downloaded": "Download complete. Available locally: {path}",
         "whisper_download_failed": "Download failed: {message}",
         "download_path_required_title": "Download directory required",
+        "tts_storage_path_required": (
+            "Select the TTS resource storage location before downloading."
+        ),
         "tts_model_path_required": (
             "Select the voice model download directory before downloading."
         ),
@@ -319,6 +330,9 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
             "Select the Whisper model download directory before downloading."
         ),
         "download_path_invalid": "The selected directory cannot be used: {message}",
+        "tts_download_path_unsafe": (
+            "The selected TTS directories are unsafe: {message}"
+        ),
         "automation_group": "Idle behavior and memory",
         "settings_help": "Explain these settings",
         "automation_help_title": "Idle behavior and memory",
@@ -497,9 +511,16 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "tts_backend_autodl": "AutoDL 云端",
         "tts_endpoint": "TTS 地址",
         "tts_timeout": "TTS 超时",
-        "tts_engine_root": "GPT-SoVITS 下载及安装目录",
+        "tts_storage_root": "TTS 资源存储位置",
+        "tts_storage_preview": (
+            "自动目录：\n"
+            "引擎：{engine}\n"
+            "语音模型：{model}"
+        ),
+        "tts_advanced_paths": "高级设置",
+        "tts_engine_root": "GPT-SoVITS 精确安装目录",
         "tts_bootstrap": "一键安装 macOS GPT-SoVITS 基础环境",
-        "tts_model_dir": "角色语音模型下载目录（含参考音频）",
+        "tts_model_dir": "角色语音模型精确目录（含参考音频）",
         "tts_autodl_ssh_command": "AutoDL SSH 登录命令",
         "tts_autodl_password": "AutoDL SSH 密码",
         "tts_autodl_remote_command": "远程 TTS 启动命令",
@@ -615,10 +636,12 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "whisper_downloaded": "下载完成，本地路径：{path}",
         "whisper_download_failed": "下载失败：{message}",
         "download_path_required_title": "需要填写下载目录",
+        "tts_storage_path_required": "请先选择 TTS 资源存储位置。",
         "tts_model_path_required": "请先选择角色语音模型下载目录。",
         "tts_engine_path_required": "请先选择 GPT-SoVITS 下载及安装目录。",
         "whisper_path_required": "请先选择 Whisper 模型下载目录。",
         "download_path_invalid": "无法使用所选目录：{message}",
+        "tts_download_path_unsafe": "所选 TTS 目录不安全：{message}",
         "automation_group": "空闲行为与记忆",
         "settings_help": "解释这些设置",
         "automation_help_title": "空闲行为与记忆说明",
@@ -963,6 +986,12 @@ class SettingsDialog(QDialog):
             self._on_tts_backend_changed
         )
         self.tts_url.editingFinished.connect(self._update_tts_state)
+        self.tts_storage_root.editingFinished.connect(
+            self._on_tts_storage_root_changed
+        )
+        self.tts_advanced_paths.toggled.connect(
+            self._on_tts_advanced_paths_changed
+        )
         self.tts_engine_root.editingFinished.connect(self._update_tts_state)
         self.tts_model_dir.editingFinished.connect(self._update_tts_state)
         self.tts_autodl_ssh_command.editingFinished.connect(
@@ -1280,6 +1309,13 @@ class SettingsDialog(QDialog):
         self.tts_backend.addItem("", "autodl")
         self.tts_url = QLineEdit()
         self.tts_timeout = self._spinbox(10, 900)
+        self.tts_storage_root = QLineEdit()
+        self.tts_storage_browse = QPushButton()
+        self.tts_storage_browse.clicked.connect(self._browse_tts_storage)
+        self.tts_path_preview = QLabel()
+        self.tts_path_preview.setWordWrap(True)
+        self.tts_path_preview.setMinimumHeight(72)
+        self.tts_advanced_paths = QCheckBox()
         self.tts_engine_root = QLineEdit()
         self.tts_engine_browse = QPushButton()
         self.tts_engine_browse.clicked.connect(self._browse_tts_engine)
@@ -1349,6 +1385,16 @@ class SettingsDialog(QDialog):
         self._add_row(tts_form, "tts_backend", self.tts_backend)
         self._add_row(tts_form, "tts_endpoint", self.tts_url)
         self._add_row(tts_form, "tts_timeout", self.tts_timeout)
+        self._add_row(
+            tts_form,
+            "tts_storage_root",
+            self._path_picker(
+                self.tts_storage_root,
+                self.tts_storage_browse,
+            ),
+        )
+        tts_form.addRow(self.tts_path_preview)
+        tts_form.addRow(self.tts_advanced_paths)
         self._add_row(
             tts_form,
             "tts_engine_root",
@@ -1754,6 +1800,8 @@ class SettingsDialog(QDialog):
         self._set_combo_data(self.tts_backend, settings.tts.backend)
         self.tts_url.setText(settings.tts.base_url)
         self.tts_timeout.setValue(settings.tts.timeout_seconds)
+        self.tts_storage_root.setText(settings.tts.storage_root)
+        self.tts_advanced_paths.setChecked(settings.tts.advanced_paths)
         self.tts_engine_root.setText(settings.tts.engine_root)
         self.tts_model_dir.setText(settings.tts.model_dir)
         self.tts_autodl_ssh_command.setText(
@@ -2019,10 +2067,15 @@ class SettingsDialog(QDialog):
         self.tts_autodl_password.setPlaceholderText(
             self._text("tts_autodl_password_placeholder")
         )
+        self.tts_storage_browse.setText(self._text("browse"))
+        self.tts_advanced_paths.setText(
+            self._text("tts_advanced_paths")
+        )
         self.tts_engine_browse.setText(self._text("browse"))
         self.tts_model_browse.setText(self._text("browse"))
         self.tts_bootstrap_button.setText(self._text("tts_bootstrap"))
         self.tts_download_button.setText(self._text("tts_download"))
+        self._update_tts_path_preview()
         self._render_tts_service_button()
         self.stt_enabled.setText(
             self._text(
@@ -2330,6 +2383,7 @@ class SettingsDialog(QDialog):
         *,
         enabled: bool | None = None,
     ) -> TTSSettings:
+        engine_root, model_dir = self._effective_tts_path_strings()
         return TTSSettings(
             enabled=(
                 self.tts_enabled.isChecked()
@@ -2338,8 +2392,10 @@ class SettingsDialog(QDialog):
             ),
             backend=self.tts_backend.currentData() or "local",
             base_url=self.tts_url.text().strip(),
-            engine_root=self.tts_engine_root.text().strip(),
-            model_dir=self.tts_model_dir.text().strip(),
+            storage_root=self.tts_storage_root.text().strip(),
+            advanced_paths=self.tts_advanced_paths.isChecked(),
+            engine_root=engine_root,
+            model_dir=model_dir,
             autodl_ssh_command=(
                 self.tts_autodl_ssh_command.text().strip()
             ),
@@ -2355,17 +2411,61 @@ class SettingsDialog(QDialog):
             timeout_seconds=self.tts_timeout.value(),
         )
 
+    def _effective_tts_path_strings(self) -> tuple[str, str]:
+        if self.tts_advanced_paths.isChecked():
+            return (
+                self.tts_engine_root.text().strip(),
+                self.tts_model_dir.text().strip(),
+            )
+        storage_root = self.tts_storage_root.text().strip()
+        if not storage_root:
+            return "", ""
+        engine, model = tts_paths_for_storage_root(storage_root)
+        return str(engine), str(model)
+
+    def _update_tts_path_preview(self) -> None:
+        if not hasattr(self, "tts_path_preview"):
+            return
+        engine, model = self._effective_tts_path_strings()
+        self.tts_path_preview.setText(
+            self._text(
+                "tts_storage_preview",
+                engine=engine or "—",
+                model=model or "—",
+            )
+        )
+
+    def _on_tts_storage_root_changed(self) -> None:
+        storage_root = self.tts_storage_root.text().strip()
+        if storage_root and not self.tts_advanced_paths.isChecked():
+            engine, model = tts_paths_for_storage_root(storage_root)
+            self.tts_engine_root.setText(str(engine))
+            self.tts_model_dir.setText(str(model))
+        self._update_tts_path_preview()
+        self._update_tts_state()
+
+    def _on_tts_advanced_paths_changed(self, checked: bool) -> None:
+        if checked:
+            engine, model = tts_paths_for_storage_root(
+                self.tts_storage_root.text().strip() or Path.home()
+            )
+            if not self.tts_engine_root.text().strip():
+                self.tts_engine_root.setText(str(engine))
+            if not self.tts_model_dir.text().strip():
+                self.tts_model_dir.setText(str(model))
+        self._update_tts_path_preview()
+        self._update_tts_state()
+
     def _set_tts_path_controls(self, *, downloading: bool) -> None:
         enabled = self.tts_enabled.isChecked()
         autodl = self.tts_backend.currentData() == "autodl"
         controls_enabled = enabled and not downloading
         local_enabled = controls_enabled and not autodl
         autodl_enabled = controls_enabled and autodl
-        local_keys = (
-            "tts_endpoint",
-            "tts_engine_root",
-            "tts_model_dir",
-        )
+        normal_paths = not self.tts_advanced_paths.isChecked()
+        local_keys = ("tts_endpoint",)
+        normal_path_keys = ("tts_storage_root",)
+        advanced_path_keys = ("tts_engine_root", "tts_model_dir")
         autodl_keys = (
             "tts_autodl_ssh_command",
             "tts_autodl_password",
@@ -2376,10 +2476,13 @@ class SettingsDialog(QDialog):
         self.tts_backend.setEnabled(controls_enabled)
         self.tts_timeout.setEnabled(controls_enabled)
         self.tts_url.setEnabled(local_enabled)
-        self.tts_engine_root.setEnabled(local_enabled)
-        self.tts_engine_browse.setEnabled(local_enabled)
-        self.tts_model_dir.setEnabled(local_enabled)
-        self.tts_model_browse.setEnabled(local_enabled)
+        self.tts_storage_root.setEnabled(local_enabled and normal_paths)
+        self.tts_storage_browse.setEnabled(local_enabled and normal_paths)
+        self.tts_advanced_paths.setEnabled(local_enabled)
+        self.tts_engine_root.setEnabled(local_enabled and not normal_paths)
+        self.tts_engine_browse.setEnabled(local_enabled and not normal_paths)
+        self.tts_model_dir.setEnabled(local_enabled and not normal_paths)
+        self.tts_model_browse.setEnabled(local_enabled and not normal_paths)
         for field in (
             self.tts_autodl_ssh_command,
             self.tts_autodl_password,
@@ -2389,12 +2492,23 @@ class SettingsDialog(QDialog):
             field.setEnabled(autodl_enabled)
 
         self._set_form_rows_visible(local_keys, not autodl)
+        self._set_form_rows_visible(
+            normal_path_keys,
+            not autodl and normal_paths,
+        )
+        self._set_form_rows_visible(
+            advanced_path_keys,
+            not autodl and not normal_paths,
+        )
         self._set_form_rows_visible(autodl_keys, autodl)
+        self.tts_path_preview.setVisible(not autodl and normal_paths)
+        self.tts_advanced_paths.setVisible(not autodl)
         self.tts_download_button.setVisible(not autodl)
-        self.tts_bootstrap_button.setVisible(
+        bootstrap_visible = (
             not autodl
             and self._platform_runtime.capabilities.managed_tts_bootstrap
         )
+        self._set_form_rows_visible(("tts_bootstrap",), bootstrap_visible)
         self.tts_bootstrap_button.setEnabled(
             local_enabled
             and self._tts_bootstrap_worker is None
@@ -2410,6 +2524,14 @@ class SettingsDialog(QDialog):
         self._set_form_labels_enabled(
             local_keys,
             local_enabled,
+        )
+        self._set_form_labels_enabled(
+            normal_path_keys,
+            local_enabled and normal_paths,
+        )
+        self._set_form_labels_enabled(
+            advanced_path_keys,
+            local_enabled and not normal_paths,
         )
         self._set_form_labels_enabled(
             ("tts_bootstrap",),
@@ -2508,14 +2630,15 @@ class SettingsDialog(QDialog):
                 self._set_tts_status("tts_external_offline")
             return
 
-        configured_engine = self.tts_engine_root.text().strip()
-        if state.engine_root is not None and not configured_engine:
-            self.tts_engine_root.setText(str(state.engine_root))
-        if (
-            state.model_directory is not None
-            and not self.tts_model_dir.text().strip()
-        ):
-            self.tts_model_dir.setText(str(state.model_directory))
+        if self.tts_advanced_paths.isChecked():
+            configured_engine = self.tts_engine_root.text().strip()
+            if state.engine_root is not None and not configured_engine:
+                self.tts_engine_root.setText(str(state.engine_root))
+            if (
+                state.model_directory is not None
+                and not self.tts_model_dir.text().strip()
+            ):
+                self.tts_model_dir.setText(str(state.model_directory))
 
         self._tts_engine_download_needed = (
             self._platform_runtime.capabilities.managed_archives
@@ -2684,14 +2807,37 @@ class SettingsDialog(QDialog):
             return
         if self.tts_backend.currentData() == "autodl":
             return
-        model_destination = self._require_download_directory(
-            self.tts_model_dir,
-            "tts_model_path_required",
-        )
-        if model_destination is None:
-            return
-        engine_destination = None
-        if self._tts_engine_download_needed:
+        if self.tts_advanced_paths.isChecked():
+            model_destination = self._require_download_directory(
+                self.tts_model_dir,
+                "tts_model_path_required",
+            )
+            if model_destination is None:
+                return
+            engine_destination = None
+            if self._tts_engine_download_needed:
+                engine_destination = self._require_download_directory(
+                    self.tts_engine_root,
+                    "tts_engine_path_required",
+                )
+                if engine_destination is None:
+                    return
+        else:
+            storage_root = self._require_download_directory(
+                self.tts_storage_root,
+                "tts_storage_path_required",
+            )
+            if storage_root is None:
+                return
+            derived_engine, model_destination = tts_paths_for_storage_root(
+                storage_root
+            )
+            engine_destination = (
+                derived_engine if self._tts_engine_download_needed else None
+            )
+            self._update_tts_path_preview()
+
+        if self._tts_engine_download_needed and engine_destination is None:
             engine_destination = self._require_download_directory(
                 self.tts_engine_root,
                 "tts_engine_path_required",
@@ -2711,11 +2857,19 @@ class SettingsDialog(QDialog):
         )
         if answer != QMessageBox.Yes:
             return
-        self.download_manager.start_tts(
-            model_destination,
-            include_engine=self._tts_engine_download_needed,
-            engine_destination=engine_destination,
-        )
+        try:
+            self.download_manager.start_tts(
+                model_destination,
+                include_engine=self._tts_engine_download_needed,
+                engine_destination=engine_destination,
+            )
+        except (OSError, RuntimeError, ValueError) as exc:
+            QMessageBox.warning(
+                self,
+                self._text("download_path_required_title"),
+                self._text("tts_download_path_unsafe", message=exc),
+            )
+            return
         self._set_tts_path_controls(downloading=True)
         self.tts_download_button.setEnabled(False)
         self._render_tts_download(
@@ -2729,10 +2883,21 @@ class SettingsDialog(QDialog):
             or not self._platform_runtime.capabilities.managed_tts_bootstrap
         ):
             return
-        engine_root = self._require_download_directory(
-            self.tts_engine_root,
-            "tts_engine_path_required",
-        )
+        if self.tts_advanced_paths.isChecked():
+            engine_root = self._require_download_directory(
+                self.tts_engine_root,
+                "tts_engine_path_required",
+            )
+        else:
+            storage_root = self._require_download_directory(
+                self.tts_storage_root,
+                "tts_storage_path_required",
+            )
+            engine_root = (
+                tts_paths_for_storage_root(storage_root)[0]
+                if storage_root is not None
+                else None
+            )
         if engine_root is None:
             return
         answer = QMessageBox.question(
@@ -2768,7 +2933,11 @@ class SettingsDialog(QDialog):
         self._set_tts_status("tts_bootstrap_installing", detail=detail)
 
     def _on_tts_bootstrap_succeeded(self, path: str) -> None:
-        self.tts_engine_root.setText(path)
+        if self.tts_advanced_paths.isChecked():
+            self.tts_engine_root.setText(path)
+        else:
+            self.tts_storage_root.setText(str(Path(path).parent))
+            self._update_tts_path_preview()
         self._set_tts_status("tts_bootstrap_installed", path=path)
 
     def _on_tts_bootstrap_failed(self, message: str) -> None:
@@ -2863,7 +3032,8 @@ class SettingsDialog(QDialog):
                 self._render_tts_download(snapshot)
             elif snapshot.status == "completed":
                 self.tts_download_button.setEnabled(False)
-                self.tts_model_dir.setText(snapshot.destination)
+                if self.tts_advanced_paths.isChecked():
+                    self.tts_model_dir.setText(snapshot.destination)
                 self._render_progress(self.tts_progress, snapshot)
                 self.tts_extract_progress.hide()
                 self._set_tts_status(
@@ -3000,6 +3170,16 @@ class SettingsDialog(QDialog):
                 return f"{size:.1f} {unit}"
             size /= 1024
         return f"{size:.1f} TB"
+
+    def _browse_tts_storage(self) -> None:
+        selected = QFileDialog.getExistingDirectory(
+            self,
+            self._text("tts_storage_root"),
+            self.tts_storage_root.text().strip() or str(Path.home()),
+        )
+        if selected:
+            self.tts_storage_root.setText(selected)
+            self._on_tts_storage_root_changed()
 
     def _browse_tts_engine(self) -> None:
         selected = QFileDialog.getExistingDirectory(

--- a/config.example.json
+++ b/config.example.json
@@ -29,6 +29,8 @@
     "enabled": false,
     "backend": "local",
     "base_url": "http://127.0.0.1:9880/tts",
+    "storage_root": "C:/AIpet/models/tts",
+    "advanced_paths": false,
     "engine_root": "C:/AIpet/models/tts/GPT-SoVITS",
     "model_dir": "C:/AIpet/models/tts/Murasame_SoVITS",
     "autodl_ssh_command": "",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -43,6 +43,7 @@ from aipet.core.config import (
     VisionSettings,
     default_tts_engine_root,
     default_tts_model_dir,
+    default_tts_storage_root,
     default_whisper_model_dir,
     get_model_dir,
     load_settings,
@@ -251,6 +252,11 @@ class CoreTests(unittest.TestCase):
                 )
                 self.assertEqual(tts.model_dir, default_tts_model_dir())
                 self.assertEqual(
+                    tts.storage_root,
+                    default_tts_storage_root(),
+                )
+                self.assertFalse(tts.advanced_paths)
+                self.assertEqual(
                     stt.model_dir,
                     default_whisper_model_dir("large-v3"),
                 )
@@ -264,6 +270,34 @@ class CoreTests(unittest.TestCase):
         )
         self.assertEqual(custom.engine_root, "D:/custom/GPT-SoVITS")
         self.assertEqual(custom.model_dir, "D:/custom/Murasame")
+        self.assertTrue(custom.advanced_paths)
+
+    def test_legacy_standard_tts_paths_use_storage_root_mode(self) -> None:
+        settings = TTSSettings.model_validate(
+            {
+                "engine_root": "/models/tts/GPT-SoVITS",
+                "model_dir": "/models/tts/Murasame_SoVITS",
+            }
+        )
+
+        self.assertFalse(settings.advanced_paths)
+        self.assertEqual(settings.storage_root, "/models/tts")
+        self.assertEqual(
+            settings.engine_root,
+            "/models/tts/GPT-SoVITS",
+        )
+
+    def test_legacy_custom_tts_paths_preserve_advanced_mode(self) -> None:
+        settings = TTSSettings.model_validate(
+            {
+                "engine_root": "/engine/custom-name",
+                "model_dir": "/voice/custom-name",
+            }
+        )
+
+        self.assertTrue(settings.advanced_paths)
+        self.assertEqual(settings.engine_root, "/engine/custom-name")
+        self.assertEqual(settings.model_dir, "/voice/custom-name")
 
     def test_stt_language_supports_detection_and_whisper_codes(self) -> None:
         self.assertIsNone(

--- a/tests/test_download_manager.py
+++ b/tests/test_download_manager.py
@@ -14,6 +14,7 @@ import requests
 
 from aipet.core.download_manager import (
     BUNDLED_7ZIP,
+    GPT_SOVITS_MANAGED_MARKER,
     HUGGING_FACE_ENDPOINT,
     HUGGING_FACE_MIRROR_ENDPOINT,
     MODELSCOPE_ENDPOINT,
@@ -31,6 +32,8 @@ from aipet.core.download_manager import (
     _modelscope_url,
     _sha256,
     _tts_files,
+    _validate_engine_install_destination,
+    _validate_tts_destinations,
     _whisper_files,
     select_tts_engine_archive,
 )
@@ -145,6 +148,10 @@ class DownloadWorkerTests(unittest.TestCase):
             (source / "api_v2.py").write_text("new", encoding="utf-8")
             destination = root / "GPT-SoVITS"
             destination.mkdir()
+            (destination / GPT_SOVITS_MANAGED_MARKER).write_text(
+                "{}\n",
+                encoding="utf-8",
+            )
             (destination / "api_v2.py").write_text(
                 "old",
                 encoding="utf-8",
@@ -169,6 +176,39 @@ class DownloadWorkerTests(unittest.TestCase):
             self.assertFalse(
                 any(root.glob(".GPT-SoVITS-backup-*"))
             )
+            self.assertTrue(
+                (destination / GPT_SOVITS_MANAGED_MARKER).is_file()
+            )
+
+    def test_engine_install_rejects_filesystem_root(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "filesystem root"):
+            _validate_engine_install_destination(Path(Path.cwd().anchor))
+
+    def test_engine_install_refuses_unmanaged_nonempty_directory(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            destination = Path(directory) / "documents"
+            destination.mkdir()
+            important = destination / "important.txt"
+            important.write_text("keep me", encoding="utf-8")
+
+            with self.assertRaisesRegex(RuntimeError, "not marked"):
+                _validate_engine_install_destination(destination)
+
+            self.assertEqual(
+                important.read_text(encoding="utf-8"),
+                "keep me",
+            )
+
+    def test_tts_directories_must_be_disjoint(self) -> None:
+        root = Path("/tmp/aipet-path-test")
+        with self.assertRaisesRegex(RuntimeError, "cannot contain"):
+            _validate_tts_destinations(root, root)
+        with self.assertRaisesRegex(RuntimeError, "cannot contain"):
+            _validate_tts_destinations(root / "voice", root)
+        with self.assertRaisesRegex(RuntimeError, "cannot contain"):
+            _validate_tts_destinations(root, root / "engine")
 
     @unittest.skipUnless(
         sys.platform == "win32",

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -332,6 +332,9 @@ class UISmokeTests(unittest.TestCase):
                 dialog.tts_backend,
                 dialog.tts_url,
                 dialog.tts_timeout,
+                dialog.tts_storage_root,
+                dialog.tts_storage_browse,
+                dialog.tts_advanced_paths,
                 dialog.tts_engine_root,
                 dialog.tts_engine_browse,
                 dialog.tts_model_dir,
@@ -349,6 +352,7 @@ class UISmokeTests(unittest.TestCase):
                 "tts_backend",
                 "tts_endpoint",
                 "tts_timeout",
+                "tts_storage_root",
                 "tts_engine_root",
                 "tts_model_dir",
                 "tts_autodl_ssh_command",
@@ -368,23 +372,30 @@ class UISmokeTests(unittest.TestCase):
         settings.tts.backend = "local"
         dialog = SettingsDialog(settings)
         try:
-            local_keys = (
-                "tts_endpoint",
-                "tts_engine_root",
-                "tts_model_dir",
-            )
+            normal_local_keys = ("tts_endpoint", "tts_storage_root")
+            advanced_local_keys = ("tts_engine_root", "tts_model_dir")
+            all_local_keys = normal_local_keys + advanced_local_keys
             autodl_keys = (
                 "tts_autodl_ssh_command",
                 "tts_autodl_password",
                 "tts_autodl_remote_command",
                 "tts_autodl_reference_root",
             )
-            for key in local_keys:
+            for key in normal_local_keys:
                 self.assertFalse(
                     dialog._form_fields[key][0].isHidden(),
                     key,
                 )
                 self.assertFalse(
+                    dialog._form_labels[key][0].isHidden(),
+                    key,
+                )
+            for key in advanced_local_keys:
+                self.assertTrue(
+                    dialog._form_fields[key][0].isHidden(),
+                    key,
+                )
+                self.assertTrue(
                     dialog._form_labels[key][0].isHidden(),
                     key,
                 )
@@ -400,7 +411,7 @@ class UISmokeTests(unittest.TestCase):
             self.assertFalse(dialog.tts_download_button.isHidden())
 
             dialog._set_combo_data(dialog.tts_backend, "autodl")
-            for key in local_keys:
+            for key in all_local_keys:
                 self.assertTrue(
                     dialog._form_fields[key][0].isHidden(),
                     key,
@@ -421,6 +432,78 @@ class UISmokeTests(unittest.TestCase):
             self.assertTrue(dialog.tts_download_button.isHidden())
         finally:
             dialog.close()
+
+    def test_tts_advanced_paths_switches_exact_directory_rows(self) -> None:
+        settings = AppSettings(ui_language="zh-CN")
+        dialog = SettingsDialog(settings)
+        try:
+            dialog.tts_enabled.blockSignals(True)
+            dialog.tts_enabled.setChecked(True)
+            dialog.tts_enabled.blockSignals(False)
+            dialog.tts_storage_root.setText("D:/AIpet/models/tts")
+            dialog._set_tts_path_controls(downloading=False)
+
+            engine, model = dialog._effective_tts_path_strings()
+            self.assertEqual(engine, "D:/AIpet/models/tts/GPT-SoVITS")
+            self.assertEqual(
+                model,
+                "D:/AIpet/models/tts/Murasame_SoVITS",
+            )
+            self.assertFalse(
+                dialog._form_fields["tts_storage_root"][0].isHidden()
+            )
+            self.assertTrue(
+                dialog._form_fields["tts_engine_root"][0].isHidden()
+            )
+
+            dialog.tts_advanced_paths.blockSignals(True)
+            dialog.tts_advanced_paths.setChecked(True)
+            dialog.tts_advanced_paths.blockSignals(False)
+            dialog._set_tts_path_controls(downloading=False)
+
+            self.assertTrue(
+                dialog._form_fields["tts_storage_root"][0].isHidden()
+            )
+            self.assertFalse(
+                dialog._form_fields["tts_engine_root"][0].isHidden()
+            )
+            self.assertFalse(
+                dialog._form_fields["tts_model_dir"][0].isHidden()
+            )
+        finally:
+            dialog.close()
+
+    def test_tts_download_derives_managed_subdirectories(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            settings = AppSettings(ui_language="zh-CN")
+            dialog = SettingsDialog(settings)
+            try:
+                root = Path(directory).resolve()
+                dialog.tts_enabled.blockSignals(True)
+                dialog.tts_enabled.setChecked(True)
+                dialog.tts_enabled.blockSignals(False)
+                dialog.tts_storage_root.setText(str(root))
+                dialog.tts_advanced_paths.setChecked(False)
+                dialog._tts_engine_download_needed = False
+                with (
+                    patch(
+                        "aipet.ui.settings_dialog.QMessageBox.question",
+                        return_value=QMessageBox.Yes,
+                    ),
+                    patch.object(
+                        dialog.download_manager,
+                        "start_tts",
+                    ) as start_tts,
+                ):
+                    dialog._request_tts_download()
+
+                start_tts.assert_called_once_with(
+                    root / "Murasame_SoVITS",
+                    include_engine=False,
+                    engine_destination=None,
+                )
+            finally:
+                dialog.close()
 
     def test_settings_help_buttons_replace_empty_title_bar_help(
         self,
@@ -651,6 +734,10 @@ class UISmokeTests(unittest.TestCase):
                     os.environ["AIPET_MODEL_DIR"]
                 ).resolve()
                 self.assertEqual(
+                    Path(dialog.tts_storage_root.text()),
+                    default_model_root / "tts",
+                )
+                self.assertEqual(
                     Path(dialog.tts_engine_root.text()),
                     default_model_root / "tts" / "GPT-SoVITS",
                 )
@@ -702,7 +789,7 @@ class UISmokeTests(unittest.TestCase):
                 dialog.tts_enabled.blockSignals(True)
                 dialog.tts_enabled.setChecked(True)
                 dialog.tts_enabled.blockSignals(False)
-                dialog.tts_model_dir.clear()
+                dialog.tts_storage_root.clear()
                 with (
                     patch(
                         "aipet.ui.settings_dialog.QMessageBox.warning"
@@ -908,6 +995,9 @@ class UISmokeTests(unittest.TestCase):
                 dialog.tts_enabled.blockSignals(True)
                 dialog.tts_enabled.setChecked(True)
                 dialog.tts_enabled.blockSignals(False)
+                dialog.tts_advanced_paths.blockSignals(True)
+                dialog.tts_advanced_paths.setChecked(True)
+                dialog.tts_advanced_paths.blockSignals(False)
                 dialog.tts_engine_root.setText(
                     str(Path(directory) / "tts-engine-download")
                 )


### PR DESCRIPTION
## 变更

- 新增统一的 TTS 资源存储目录，自动使用 `GPT-SoVITS` 与 `Murasame_SoVITS` 子目录
- 保留“高级设置”，允许分别指定两个精确目录
- 拒绝磁盘根目录、符号链接、非空且非 AIpet 管理的 GPT-SoVITS 目录
- 防止引擎目录与语音模型目录相同或相互嵌套
- 兼容并迁移已有 TTS 路径配置
- 精简目录预览与高级设置界面文字

## 原因与影响

旧安装流程会先将现有 GPT-SoVITS 目标目录改名为备份目录，再用新下载内容替换它。用户若把目标误设为 `C:\\`，程序会尝试移动系统盘根目录并触发 `WinError 32`；普通非空目录也存在误移动或删除用户文件的风险。

修复后，普通模式只需选择一个存储根目录，程序只管理其下两个固定子目录；危险或不属于 AIpet 管理的目标会在下载前被拒绝。

## 验证

- 核心与下载管理测试：57 项，无失败（7 项按平台条件跳过）
- Qt 界面测试：19 项，无失败
- `python -m compileall -q aipet tests`
- `git diff --check`

尚未在真实 Windows 环境完成大型 GPT-SoVITS 归档的端到端下载测试。